### PR TITLE
[doc] add osx build instructions for homebrew

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -34,6 +34,9 @@ Now, you can build!
     ./configure
     make
 
+You should also run `make check` in order to run tests. This is a vital step
+early in the development of `picocoin`.
+
 You can install it if you want with `make install`. It will be installed to 
 `/usr/local/picocoin`.
 


### PR DESCRIPTION
Tested on OS X 10.8. I saw in the forum thread that someone [built on 10.7](https://bitcointalk.org/index.php?topic=128055.msg1362516#msg1362516), so I figure these are probably OK for 10.7, too. 

I no longer have access to a 10.6 box to try there.
