### PR TITLE
[doc] update osx build to use brew's openssl

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -31,7 +31,7 @@ Building
 Now, you can build!
 
     ./autogen.sh
-    ./configure
+    ./configure CPPFLAGS="-I`brew --prefix openssl`/include"
     make
 
 You should also run `make check` in order to run tests. This is a vital step


### PR DESCRIPTION
I realized just now out of some strange feeling that I neglected to tell configure to use Homebrew's openssl in the instructions. This instantaneously makes all of the deprecation warnings go away!
