### PR TITLE
Substitute functions requiring glib > 2.28

### DIFF
--- a/include/ccoin/compat.h
+++ b/include/ccoin/compat.h
@@ -21,6 +21,14 @@ g_ptr_array_new_full (guint          reserved_size,
   g_ptr_array_set_free_func (array, element_free_func);
   return array;
 }
+
+static inline void
+g_list_free_full(GList *element_list,
+		      GDestroyNotify free_func)
+{
+  g_list_foreach(element_list, (GFunc)free_func, NULL);
+  g_list_free(element_list);
+}
 #endif /* GLIB_VERSION < 2.30 */
 
 #ifndef HAVE_FDATASYNC

--- a/lib/utxo.c
+++ b/lib/utxo.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <ccoin/core.h>
+#include <ccoin/compat.h>
 
 void bp_utxo_init(struct bp_utxo *coin)
 {

--- a/src/peerman.c
+++ b/src/peerman.c
@@ -9,6 +9,7 @@
 #include <ccoin/mbr.h>
 #include <ccoin/util.h>
 #include <ccoin/coredefs.h>
+#include <ccoin/compat.h>
 #include "picocoin.h"
 
 static guint addr_hash(gconstpointer key)

--- a/test/script-parse.c
+++ b/test/script-parse.c
@@ -16,6 +16,7 @@
 #include <ccoin/core.h>
 #include <ccoin/mbr.h>
 #include <ccoin/message.h>
+#include <ccoin/compat.h>
 #include "libtest.h"
 
 static void test_txout(const struct bp_txout *txout)


### PR DESCRIPTION
Configure declares glib 2.0.0 is enough, but some functions (convenience only) were introduced in glib 2.28.

This patch adds wrappers for old glib constructs in compat.h and adds the header where its missing.
