### PR TITLE
GLib <2.30 compat header added to serialize.c

### DIFF
--- a/lib/serialize.c
+++ b/lib/serialize.c
@@ -11,6 +11,7 @@
 #include <openssl/bn.h>
 #include <ccoin/serialize.h>
 #include <ccoin/util.h>
+#include <ccoin/compat.h>
 
 void ser_bytes(GString *s, const void *p, size_t len)
 {


### PR DESCRIPTION
grants correct compilation on system with older GLib
