### PR TITLE
fix linux compile issue

### DIFF
--- a/include/ccoin/util.h
+++ b/include/ccoin/util.h
@@ -6,6 +6,7 @@
  */
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 #include <glib.h>
 #include <openssl/bn.h>

--- a/lib/util.c
+++ b/lib/util.c
@@ -4,7 +4,7 @@
  */
 #include "picocoin-config.h"
 
-#include <stdint.h>
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
uint64_t not available in util.h depending on how headers are parsed.
