### PR TITLE
add timestamp to bp_key

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -22,5 +22,8 @@ extern void wallet_info(void);
 extern void wallet_dump(void);
 extern void wallet_addresses(void);
 extern void cur_wallet_free(void);
+extern time_t wallet_oldest_key_time(void);
 
+/* check if there is a key in wallet (bu_Hash160 comp. against buf) */
+extern bool wallet_lookup_pubkey(const void *data, size_t data_len);
 #endif /* __PICOCOIN_WALLET_H__ */


### PR DESCRIPTION
timestamp will be needed for SPV mode "fast catchup" blockchain load.

bitcoinj/Multibit does it the same way. Check:
http://bitcoinj.googlecode.com/git-history/3d6691c82a09f7a072f25766720abf0a6d242ef0/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java

