### PR TITLE
Various fixes

### DIFF
--- a/src/wallet.c
+++ b/src/wallet.c
@@ -298,8 +298,6 @@ void cur_wallet_free(void)
 		return;
 
 	wallet_free(cur_wallet);
-	free(cur_wallet);
-
 	cur_wallet = NULL;
 }
 


### PR DESCRIPTION
Newer OpenSSL releases are less liberal in how ECDSA signature verification is performed; rejecting previously "valid" TX signatures that exist in the blockchain[1].  Solve this problem in a similar way to how bitcoin-core solves it.  "Normalize" the ECDSA signature by parsing it explicitly before using ECDSA_do_verify() to verify.

Also, fix up a minor double-free error caught by clang-analyzer.

Now 'make check' passes!

[1]: See 23b397edccd3740a74adb603c9756370fafcde9bcc4483eb271ecad09a94dd63