### PR TITLE
Make picocoin wallet handling code more generic, push into libccoin

### DIFF
--- a/include/ccoin/Makefile.am
+++ b/include/ccoin/Makefile.am
@@ -23,5 +23,6 @@ EXTRA_DIST = \
 	parr.h		\
 	script.h	\
 	serialize.h	\
-	util.h
+	util.h		\
+	wallet.h
 

--- a/include/ccoin/key.h
+++ b/include/ccoin/key.h
@@ -21,12 +21,12 @@ extern bool bp_key_generate(struct bp_key *key);
 extern bool bp_privkey_set(struct bp_key *key, const void *privkey, size_t pk_len);
 extern bool bp_pubkey_set(struct bp_key *key, const void *pubkey, size_t pk_len);
 extern bool bp_key_secret_set(struct bp_key *key, const void *privkey_, size_t pk_len);
-extern bool bp_privkey_get(struct bp_key *key, void **privkey, size_t *pk_len);
-extern bool bp_pubkey_get(struct bp_key *key, void **pubkey, size_t *pk_len);
+extern bool bp_privkey_get(const struct bp_key *key, void **privkey, size_t *pk_len);
+extern bool bp_pubkey_get(const struct bp_key *key, void **pubkey, size_t *pk_len);
 extern bool bp_key_secret_get(void *p, size_t len, const struct bp_key *key);
-extern bool bp_sign(struct bp_key *key, const void *data, size_t data_len,
+extern bool bp_sign(const struct bp_key *key, const void *data, size_t data_len,
 	     void **sig_, size_t *sig_len_);
-extern bool bp_verify(struct bp_key *key, const void *data, size_t data_len,
+extern bool bp_verify(const struct bp_key *key, const void *data, size_t data_len,
 	       const void *sig, size_t sig_len);
 
 struct bp_keyset {

--- a/include/ccoin/wallet.h
+++ b/include/ccoin/wallet.h
@@ -1,0 +1,43 @@
+#ifndef __LIBCCOIN_WALLET_H__
+#define __LIBCCOIN_WALLET_H__
+/* Copyright 2012 exMULTI, Inc.
+ * Copyright 2015 Josh Cartwright <joshc@eso.teric.us>
+ *
+ * Distributed under the MIT/X11 software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <ccoin/cstr.h>
+#include <ccoin/parr.h>
+
+struct chain_info;
+
+struct wallet {
+	uint32_t		version;
+	const struct chain_info	*chain;
+
+	parr			*keys;
+};
+
+struct const_buffer;
+
+extern struct wallet *wallet_new(const struct chain_info *chain);
+extern void wallet_free(struct wallet *wlt);
+extern cstring *wallet_new_address(struct wallet *wlt);
+extern cstring *ser_wallet(const struct wallet *wlt);
+extern bool deser_wallet(struct wallet *wlt, struct const_buffer *buf);
+
+#define wallet_for_each_key_numbered(_wlt, _key, _num)			\
+	(_num) = 0;							\
+	for ((_key) = parr_idx((_wlt)->keys, (_num));		\
+		(_wlt)->keys && (_num) < (_wlt)->keys->len;		\
+		(_key) = parr_idx((_wlt)->keys, ++(_num)))
+
+#define wallet_for_each_key(_wlt, _key)				\
+	unsigned int ___i;					\
+	wallet_for_each_key_numbered(_wlt, _key, ___i)
+
+
+#endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -37,5 +37,6 @@ libccoin_a_SOURCES=	\
 	script_sign.c	\
 	serialize.c	\
 	util.c		\
-	utxo.c
+	utxo.c		\
+	wallet.c
 

--- a/lib/key.c
+++ b/lib/key.c
@@ -138,7 +138,7 @@ err_out:
 	return false;
 }
 
-bool bp_privkey_get(struct bp_key *key, void **privkey, size_t *pk_len)
+bool bp_privkey_get(const struct bp_key *key, void **privkey, size_t *pk_len)
 {
 	if (!EC_KEY_check_key(key->k))
 		return false;
@@ -154,7 +154,7 @@ bool bp_privkey_get(struct bp_key *key, void **privkey, size_t *pk_len)
 	return true;
 }
 
-bool bp_pubkey_get(struct bp_key *key, void **pubkey, size_t *pk_len)
+bool bp_pubkey_get(const struct bp_key *key, void **pubkey, size_t *pk_len)
 {
 	if (!EC_KEY_check_key(key->k))
 		return false;
@@ -192,7 +192,7 @@ bool bp_key_secret_get(void *p, size_t len, const struct bp_key *key)
 	return true;
 }
 
-bool bp_sign(struct bp_key *key, const void *data, size_t data_len,
+bool bp_sign(const struct bp_key *key, const void *data, size_t data_len,
 	     void **sig_, size_t *sig_len_)
 {
 	size_t sig_sz = ECDSA_size(key->k);
@@ -211,7 +211,7 @@ bool bp_sign(struct bp_key *key, const void *data, size_t data_len,
 	return true;
 }
 
-bool bp_verify(struct bp_key *key, const void *data, size_t data_len,
+bool bp_verify(const struct bp_key *key, const void *data, size_t data_len,
 	       const void *sig_, size_t sig_len)
 {
 	const unsigned char *sig = sig_;

--- a/lib/wallet.c
+++ b/lib/wallet.c
@@ -1,0 +1,199 @@
+/* Copyright 2012 exMULTI, Inc.
+ * Copyright 2015 Josh Cartwright <joshc@eso.teric.us>
+ *
+ * Distributed under the MIT/X11 software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+#include "picocoin-config.h"
+
+#include <ccoin/address.h>
+#include <ccoin/coredefs.h>
+#include <ccoin/key.h>
+#include <ccoin/mbr.h>
+#include <ccoin/message.h>
+#include <ccoin/wallet.h>
+
+struct wallet *wallet_new(const struct chain_info *chain)
+{
+	struct wallet *wlt;
+
+	wlt = calloc(1, sizeof(*wlt));
+	wlt->keys = parr_new(1000, free);
+	wlt->chain = chain;
+
+	return wlt;
+}
+
+void wallet_free(struct wallet *wlt)
+{
+	struct bp_key *key;
+
+	if (!wlt)
+		return;
+
+	wallet_for_each_key(wlt, key)
+		bp_key_free(key);
+
+	parr_free(wlt->keys, true);
+	wlt->keys = NULL;
+
+	memset(wlt, 0, sizeof(*wlt));
+	free(wlt);
+}
+
+cstring *wallet_new_address(struct wallet *wlt)
+{
+	struct bp_key *key;
+
+	key = calloc(1, sizeof(*key));
+	if (!bp_key_init(key)) {
+		free(key);
+		fprintf(stderr, "wallet: key init failed\n");
+		return;
+	}
+
+	if (!bp_key_generate(key)) {
+		bp_key_free(key);
+		free(key);
+		fprintf(stderr, "wallet: key gen failed\n");
+		return;
+	}
+
+	parr_add(wlt->keys, key);
+
+	return bp_pubkey_get_address(key, wlt->chain->addr_pubkey);
+}
+
+static cstring *ser_wallet_root(const struct wallet *wlt)
+{
+	cstring *rs = cstr_new_sz(8);
+
+	ser_u32(rs, wlt->version);
+	ser_bytes(rs, &wlt->chain->netmagic[0], 4);
+
+	return rs;
+}
+
+cstring *ser_wallet(const struct wallet *wlt)
+{
+	struct bp_key *key;
+
+	cstring *rs = cstr_new_sz(20 * 1024);
+
+	/*
+	 * ser "root" record
+	 */
+	cstring *s_root = ser_wallet_root(wlt);
+	cstring *recdata = message_str(wlt->chain->netmagic,
+				       "root", s_root->str, s_root->len);
+	cstr_append_buf(rs, recdata->str, recdata->len);
+	cstr_free(recdata, true);
+	cstr_free(s_root, true);
+
+	/* ser "privkey" records */
+	wallet_for_each_key(wlt, key) {
+		void *privkey = NULL;
+		size_t pk_len = 0;
+
+		bp_privkey_get(key, &privkey, &pk_len);
+
+		cstring *recdata = message_str(wlt->chain->netmagic,
+					       "privkey",
+					       privkey, pk_len);
+		free(privkey);
+
+		cstr_append_buf(rs, recdata->str, recdata->len);
+		cstr_free(recdata, true);
+	}
+
+	return rs;
+}
+
+static bool deser_wallet_root(struct wallet *wlt, struct const_buffer *buf)
+{
+	unsigned char netmagic[4];
+
+	if (!deser_u32(&wlt->version, buf))
+		return false;
+
+	if (!deser_bytes(&netmagic[0], buf, 4))
+		return false;
+
+	wlt->chain = chain_find_by_netmagic(netmagic);
+	if (!wlt->chain)
+		return false;
+
+	return true;
+}
+
+static bool load_rec_privkey(struct wallet *wlt, const void *privkey, size_t pk_len)
+{
+	struct bp_key *key;
+
+	key = calloc(1, sizeof(*key));
+	if (!bp_key_init(key))
+		goto err_out;
+	if (!bp_privkey_set(key, privkey, pk_len))
+		goto err_out_kf;
+
+	parr_add(wlt->keys, key);
+
+	return true;
+
+err_out_kf:
+	bp_key_free(key);
+err_out:
+	free(key);
+	return false;
+}
+
+static bool load_rec_root(struct wallet *wlt, const void *data, size_t data_len)
+{
+	struct const_buffer buf = { data, data_len };
+
+	if (!deser_wallet_root(wlt, &buf)) return false;
+
+	if (wlt->version != 1) {
+		fprintf(stderr, "wallet root: unsupported wallet version %u\n",
+			wlt->version);
+		return false;
+	}
+
+	return true;
+}
+
+static bool load_record(struct wallet *wlt, const struct p2p_message *msg)
+{
+	if (!strncmp(msg->hdr.command, "privkey", sizeof(msg->hdr.command)))
+		return load_rec_privkey(wlt, msg->data, msg->hdr.data_len);
+
+	else if (!strncmp(msg->hdr.command, "root", sizeof(msg->hdr.command)))
+		return load_rec_root(wlt, msg->data, msg->hdr.data_len);
+
+	return true;	/* ignore unknown records */
+}
+
+bool deser_wallet(struct wallet *wlt, struct const_buffer *buf)
+{
+	struct mbuf_reader mbr;
+
+	mbr_init(&mbr, buf);
+
+	while (mbr_read(&mbr)) {
+		if (!load_record(wlt, &mbr.msg)) {
+			mbr_free(&mbr);
+			goto err_out;
+		}
+	}
+
+	if (mbr.error) {
+		mbr_free(&mbr);
+		goto err_out;
+	}
+
+	return true;
+
+err_out:
+	fprintf(stderr, "wallet: invalid data found\n");
+	return false;
+}

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -200,7 +200,7 @@ err_out:
 	return NULL;
 }
 
-static cstring *ser_wallet(struct wallet *wlt)
+cstring *ser_wallet(const struct wallet *wlt)
 {
 	struct bp_key *key;
 

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -20,34 +20,7 @@
 #include <ccoin/mbr.h>
 #include <ccoin/hexcode.h>
 #include <ccoin/compat.h>		/* for parr_new */
-
-struct wallet *wallet_new(const struct chain_info *chain)
-{
-	struct wallet *wlt;
-
-	wlt = calloc(1, sizeof(*wlt));
-	wlt->keys = parr_new(1000, free);
-	wlt->chain = chain;
-
-	return wlt;
-}
-
-void wallet_free(struct wallet *wlt)
-{
-	struct bp_key *key;
-
-	if (!wlt)
-		return;
-
-	wallet_for_each_key(wlt, key)
-		bp_key_free(key);
-
-	parr_free(wlt->keys, true);
-	wlt->keys = NULL;
-
-	memset(wlt, 0, sizeof(*wlt));
-	free(wlt);
-}
+#include <ccoin/wallet.h>
 
 static char *wallet_filename(void)
 {
@@ -55,105 +28,6 @@ static char *wallet_filename(void)
 	if (!filename)
 		filename = setting("w");
 	return filename;
-}
-
-static bool deser_wallet_root(struct wallet *wlt, struct const_buffer *buf)
-{
-	unsigned char netmagic[4];
-
-	if (!deser_u32(&wlt->version, buf))
-		return false;
-
-	if (!deser_bytes(&netmagic[0], buf, 4))
-		return false;
-
-	wlt->chain = chain_find_by_netmagic(netmagic);
-	if (!wlt->chain)
-		return false;
-
-	return true;
-}
-
-static cstring *ser_wallet_root(const struct wallet *wlt)
-{
-	cstring *rs = cstr_new_sz(8);
-
-	ser_u32(rs, wlt->version);
-	ser_bytes(rs, &wlt->chain->netmagic[0], 4);
-
-	return rs;
-}
-
-static bool load_rec_privkey(struct wallet *wlt, const void *privkey, size_t pk_len)
-{
-	struct bp_key *key;
-
-	key = calloc(1, sizeof(*key));
-	if (!bp_key_init(key))
-		goto err_out;
-	if (!bp_privkey_set(key, privkey, pk_len))
-		goto err_out_kf;
-
-	parr_add(wlt->keys, key);
-
-	return true;
-
-err_out_kf:
-	bp_key_free(key);
-err_out:
-	free(key);
-	return false;
-}
-
-static bool load_rec_root(struct wallet *wlt, const void *data, size_t data_len)
-{
-	struct const_buffer buf = { data, data_len };
-
-	if (!deser_wallet_root(wlt, &buf)) return false;
-
-	if (wlt->version != 1) {
-		fprintf(stderr, "wallet root: unsupported wallet version %u\n",
-			wlt->version);
-		return false;
-	}
-
-	return true;
-}
-
-static bool load_record(struct wallet *wlt, const struct p2p_message *msg)
-{
-	if (!strncmp(msg->hdr.command, "privkey", sizeof(msg->hdr.command)))
-		return load_rec_privkey(wlt, msg->data, msg->hdr.data_len);
-
-	else if (!strncmp(msg->hdr.command, "root", sizeof(msg->hdr.command)))
-		return load_rec_root(wlt, msg->data, msg->hdr.data_len);
-
-	return true;	/* ignore unknown records */
-}
-
-bool deser_wallet(struct wallet *wlt, struct const_buffer *buf)
-{
-	struct mbuf_reader mbr;
-
-	mbr_init(&mbr, buf);
-
-	while (mbr_read(&mbr)) {
-		if (!load_record(wlt, &mbr.msg)) {
-			mbr_free(&mbr);
-			goto err_out;
-		}
-	}
-
-	if (mbr.error) {
-		mbr_free(&mbr);
-		goto err_out;
-	}
-
-	return true;
-
-err_out:
-	fprintf(stderr, "wallet: invalid data found\n");
-	return false;
 }
 
 static struct wallet *load_wallet(void)
@@ -200,41 +74,6 @@ err_out:
 	return NULL;
 }
 
-cstring *ser_wallet(const struct wallet *wlt)
-{
-	struct bp_key *key;
-
-	cstring *rs = cstr_new_sz(20 * 1024);
-
-	/*
-	 * ser "root" record
-	 */
-	cstring *s_root = ser_wallet_root(wlt);
-	cstring *recdata = message_str(wlt->chain->netmagic,
-				       "root", s_root->str, s_root->len);
-	cstr_append_buf(rs, recdata->str, recdata->len);
-	cstr_free(recdata, true);
-	cstr_free(s_root, true);
-
-	/* ser "privkey" records */
-	wallet_for_each_key(wlt, key) {
-		void *privkey = NULL;
-		size_t pk_len = 0;
-
-		bp_privkey_get(key, &privkey, &pk_len);
-
-		cstring *recdata = message_str(wlt->chain->netmagic,
-					       "privkey",
-					       privkey, pk_len);
-		free(privkey);
-
-		cstr_append_buf(rs, recdata->str, recdata->len);
-		cstr_free(recdata, true);
-	}
-
-	return rs;
-}
-
 static bool store_wallet(struct wallet *wlt)
 {
 	char *passphrase = getenv("PICOCOIN_PASSPHRASE");
@@ -270,29 +109,6 @@ static bool cur_wallet_load(void)
 	}
 
 	return true;
-}
-
-cstring *wallet_new_address(struct wallet *wlt)
-{
-	struct bp_key *key;
-
-	key = calloc(1, sizeof(*key));
-	if (!bp_key_init(key)) {
-		free(key);
-		fprintf(stderr, "wallet: key init failed\n");
-		return;
-	}
-
-	if (!bp_key_generate(key)) {
-		bp_key_free(key);
-		free(key);
-		fprintf(stderr, "wallet: key gen failed\n");
-		return;
-	}
-
-	parr_add(wlt->keys, key);
-
-	return bp_pubkey_get_address(key, chain->addr_pubkey);
 }
 
 void cur_wallet_new_address(void)

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -259,12 +259,8 @@ static bool cur_wallet_load(void)
 	return true;
 }
 
-void cur_wallet_new_address(void)
+cstring *wallet_new_address(struct wallet *wlt)
 {
-	if (!cur_wallet_load())
-		return;
-	struct wallet *wlt = cur_wallet;
-
 	struct bp_key *key;
 
 	key = calloc(1, sizeof(*key));
@@ -283,9 +279,19 @@ void cur_wallet_new_address(void)
 
 	parr_add(wlt->keys, key);
 
-	store_wallet(wlt);
+	return bp_pubkey_get_address(key, chain->addr_pubkey);
+}
 
-	cstring *btc_addr = bp_pubkey_get_address(key, chain->addr_pubkey);
+void cur_wallet_new_address(void)
+{
+	if (!cur_wallet_load())
+		return;
+	struct wallet *wlt = cur_wallet;
+	cstring *btc_addr;
+
+	btc_addr = wallet_new_address(wlt);
+
+	store_wallet(wlt);
 
 	printf("%s\n", btc_addr->str);
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <ccoin/cstr.h>
 #include <ccoin/parr.h>
 
 struct chain_info;
@@ -20,6 +21,7 @@ struct wallet {
 
 extern struct wallet *wallet_new(const struct chain_info *chain);
 extern void wallet_free(struct wallet *wlt);
+extern cstring *wallet_new_address(struct wallet *wlt);
 
 extern void cur_wallet_new_address(void);
 extern void cur_wallet_create(void);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -24,6 +24,7 @@ struct const_buffer;
 extern struct wallet *wallet_new(const struct chain_info *chain);
 extern void wallet_free(struct wallet *wlt);
 extern cstring *wallet_new_address(struct wallet *wlt);
+extern cstring *ser_wallet(const struct wallet *wlt);
 extern bool deser_wallet(struct wallet *wlt, struct const_buffer *buf);
 
 extern void cur_wallet_new_address(void);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -19,9 +19,12 @@ struct wallet {
 	parr			*keys;
 };
 
+struct const_buffer;
+
 extern struct wallet *wallet_new(const struct chain_info *chain);
 extern void wallet_free(struct wallet *wlt);
 extern cstring *wallet_new_address(struct wallet *wlt);
+extern bool deser_wallet(struct wallet *wlt, struct const_buffer *buf);
 
 extern void cur_wallet_new_address(void);
 extern void cur_wallet_create(void);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -5,44 +5,11 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <ccoin/cstr.h>
-#include <ccoin/parr.h>
-
-struct chain_info;
-
-struct wallet {
-	uint32_t		version;
-	const struct chain_info	*chain;
-
-	parr			*keys;
-};
-
-struct const_buffer;
-
-extern struct wallet *wallet_new(const struct chain_info *chain);
-extern void wallet_free(struct wallet *wlt);
-extern cstring *wallet_new_address(struct wallet *wlt);
-extern cstring *ser_wallet(const struct wallet *wlt);
-extern bool deser_wallet(struct wallet *wlt, struct const_buffer *buf);
-
 extern void cur_wallet_new_address(void);
 extern void cur_wallet_create(void);
 extern void cur_wallet_info(void);
 extern void cur_wallet_dump(void);
 extern void cur_wallet_addresses(void);
 extern void cur_wallet_free(void);
-
-#define wallet_for_each_key_numbered(_wlt, _key, _num)			\
-	(_num) = 0;							\
-	for ((_key) = parr_idx((_wlt)->keys, (_num));		\
-		(_wlt)->keys && (_num) < (_wlt)->keys->len;		\
-		(_key) = parr_idx((_wlt)->keys, ++(_num)))
-
-#define wallet_for_each_key(_wlt, _key)				\
-	unsigned int ___i;					\
-	wallet_for_each_key_numbered(_wlt, _key, ___i)
-
 
 #endif /* __PICOCOIN_WALLET_H__ */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -19,6 +19,7 @@ script-parse
 tx
 tx-valid
 util
+wallet
 wallet-basics
 
 *.trs

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -20,11 +20,11 @@ libtest_a_SOURCES= libtest.h libtest.c
 
 noinst_PROGRAMS	= clist cstr hex hashtab base58 fileio util keyset bloom \
 		  parr script-parse tx block blockfile blkdb script \
-		  tx-valid wallet-basics chain-verf
+		  tx-valid wallet wallet-basics chain-verf
 
 TESTS		= clist cstr hex hashtab base58 fileio util keyset bloom \
 		  parr script-parse tx block blockfile blkdb script \
-		  tx-valid wallet-basics chain-verf
+		  tx-valid wallet wallet-basics chain-verf
 
 COMMON_LDADD	= libtest.a ../lib/libccoin.a \
 		  @GLIB_LIBS@ @CRYPTO_LIBS@ @JANSSON_LIBS@ @MATH_LIBS@
@@ -47,5 +47,6 @@ script_parse_LDADD	= $(COMMON_LDADD)
 tx_LDADD		= $(COMMON_LDADD)
 tx_valid_LDADD		= $(COMMON_LDADD)
 util_LDADD		= $(COMMON_LDADD)
+wallet_LDADD		= $(COMMON_LDADD)
 wallet_basics_LDADD	= $(COMMON_LDADD)
 

--- a/test/wallet.c
+++ b/test/wallet.c
@@ -1,0 +1,120 @@
+#include "picocoin-config.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <ccoin/buffer.h>
+#include <ccoin/coredefs.h>
+#include <ccoin/cstr.h>
+#include <ccoin/key.h>
+#include <ccoin/wallet.h>
+
+static bool key_eq(const struct bp_key *key1,
+		   const struct bp_key *key2)
+{
+	void *data1, *data2;
+	size_t len1, len2;
+	bool eq;
+
+	if (!bp_privkey_get(key1, &data1, &len1))
+		return false;
+
+	if (!bp_privkey_get(key2, &data2, &len2)){
+		free(data1);
+		return false;
+	}
+
+	if (len1 != len2) {
+		free(data2);
+		free(data1);
+		return false;
+	}
+
+	eq = memcmp(data1, data2, len1);
+
+	free(data1);
+	free(data2);
+
+	return eq;
+}
+
+static bool wallet_eq(const struct wallet *wlt1,
+		      const struct wallet *wlt2)
+{
+	unsigned int i;
+
+	if (wlt1->version != wlt2->version)
+		return false;
+
+	if (wlt1->chain != wlt2->chain)
+		return false;
+
+	if (wlt1->keys->len != wlt2->keys->len)
+		return false;
+
+	for (i = 0; i < wlt1->keys->len; i++) {
+		const struct bp_key *key1, *key2;
+
+		key1 = parr_idx(wlt1->keys, i);
+		key2 = parr_idx(wlt2->keys, i);
+
+		if (!key_eq(key1, key2))
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Given a wallet, wlt, ensure the following condition holds:
+ *
+ *   deser(ser(wlt)) == wlt
+ *
+ * Note that this implies ensuring that the key order is preserved
+ * during serialization/deserialization, which may be a more strict
+ * than required.
+ */
+static void check_serialization(const struct wallet *wlt)
+{
+	cstring *ser = ser_wallet(wlt);
+	struct const_buffer buf;
+	struct wallet deser;
+	bool err;
+
+	assert(ser);
+
+	buf.p = ser->str;
+	buf.len = ser->len;
+
+	assert(!deser_wallet(&deser, &buf));
+	assert(wallet_eq(wlt, &deser));
+
+	cstr_free(ser, true);
+}
+
+static void check_with_chain(const struct chain_info *chain)
+{
+	struct wallet *wlt;
+	unsigned int i;
+
+	wlt = wallet_new(chain);
+
+	for (i = 0; i < 100; i++) {
+		cstring *addr;
+
+		addr = wallet_new_address(wlt);
+		cstr_free(addr, true);
+	}
+
+	wallet_free(wlt);
+
+}
+
+int main(int argc, char *argv[])
+{
+	unsigned int i;
+
+	for (i = 0; i < CHAIN_LAST; i++)
+		check_with_chain(&chain_metadata[i]);
+
+	return 0;
+}


### PR DESCRIPTION
Yes, yes, I should have probably have been writing tests for my other pending PR...

However, testing the wallet handling code will be a bit simpler if there was better isolation between a "wallet core" and a "picocoin wallet" (where the picocoin wallet has the notion of a "current" wallet and "current" block chain).

This is the work to do just that.