### PR TITLE
Support libccoin installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 autom4te.cache
 
 *.o
+*.la
+*.lo
+
+.libs/
+/libtool
+/ltmain.sh
 
 aclocal.m4
 Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ dnl Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 AC_INIT(picocoin, 0.1git, [Jeff Garzik <jgarzik@exmulti.com>])
 AC_PREREQ(2.52)
+LT_INIT
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADERS([picocoin-config.h])

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,11 +16,11 @@ those plus `libevent` and `jansson` to build *picocoin*.
 
 Install these packages. It will take a few minutes.
 
-    brew install autoconf automake argp-standalone jansson libevent openssl
+    brew install autoconf automake libtool argp-standalone jansson libevent openssl
 
 or
 
-    sudo port install autoconf automake argp-standalone jansson libevent pkgconfig openssl
+    sudo port install autoconf automake libtool argp-standalone jansson libevent pkgconfig openssl
 
 
 Building

--- a/include/ccoin/Makefile.am
+++ b/include/ccoin/Makefile.am
@@ -1,5 +1,6 @@
+ccoinincludedir=$(includedir)/ccoin
 
-EXTRA_DIST = \
+ccoininclude_HEADERS = \
 	address.h	\
 	addr_match.h	\
 	base58.h	\

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,9 +1,10 @@
 
 AM_CPPFLAGS	= -I$(top_srcdir)/include
 
-noinst_LIBRARIES= libccoin.a
+lib_LTLIBRARIES= libccoin.la
 
-libccoin_a_SOURCES=	\
+libccoin_la_LIBADD= -lm
+libccoin_la_SOURCES=	\
 	address.c	\
 	addr_match.c	\
 	base58.c	\
@@ -39,4 +40,3 @@ libccoin_a_SOURCES=	\
 	util.c		\
 	utxo.c		\
 	wallet.c
-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ brd_SOURCES=		\
 	brd.c		\
 	brd.h
 
-brd_LDADD	= libnode.a ../lib/libccoin.a \
+brd_LDADD	= libnode.a ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @EVENT_LIBS@
 
 picocoin_SOURCES=	\
@@ -24,13 +24,13 @@ picocoin_SOURCES=	\
 	picocoin.h	\
 	wallet.c wallet.h
 
-picocoin_LDADD	= libnode.a ../lib/libccoin.a \
+picocoin_LDADD	= libnode.a ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @ARGP_LIBS@ \
 		  @EVENT_LIBS@ @JANSSON_LIBS@
 
-blkscan_LDADD	= ../lib/libccoin.a \
+blkscan_LDADD	= ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @ARGP_LIBS@
-blkstats_LDADD	= ../lib/libccoin.a \
+blkstats_LDADD	= ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @ARGP_LIBS@
-rawtx_LDADD	= ../lib/libccoin.a \
+rawtx_LDADD	= ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @ARGP_LIBS@ @JANSSON_LIBS@

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,7 +26,7 @@ TESTS		= clist cstr hex hashtab base58 fileio util keyset bloom \
 		  parr script-parse tx block blockfile blkdb script \
 		  tx-valid wallet wallet-basics chain-verf
 
-COMMON_LDADD	= libtest.a ../lib/libccoin.a \
+COMMON_LDADD	= libtest.a ../lib/libccoin.la \
 		  @CRYPTO_LIBS@ @JANSSON_LIBS@ @MATH_LIBS@
 
 base58_LDADD		= $(COMMON_LDADD)


### PR DESCRIPTION
It would be useful to have `make install` install libccoin in addition to the picocoin executable.