### PR TITLE
"relay" field in version message

### DIFF
--- a/include/ccoin/message.h
+++ b/include/ccoin/message.h
@@ -118,11 +118,13 @@ struct msg_version {
 	uint64_t	nonce;
 	char		strSubVer[80];
 	uint32_t	nStartingHeight;
+	bool		bRelay;
 };
 
 static inline void msg_version_init(struct msg_version *mv)
 {
 	memset(mv, 0, sizeof(*mv));
+	mv->bRelay = true;
 }
 
 extern bool deser_msg_version(struct msg_version *mv, struct const_buffer *buf);

--- a/lib/message.c
+++ b/lib/message.c
@@ -263,6 +263,11 @@ bool deser_msg_version(struct msg_version *mv, struct const_buffer *buf)
 		if (mv->nVersion >= 209)
 			if (!deser_u32(&mv->nStartingHeight, buf)) return false;
 	}
+	if (mv->nVersion >= 70001) {
+		if (!deser_bool(&mv->bRelay, buf)) return false;
+	} else {
+		mv->bRelay = true;
+	}
 
 	return true;
 }
@@ -281,6 +286,9 @@ cstring *ser_msg_version(const struct msg_version *mv)
 	ser_u64(s, mv->nonce);
 	ser_str(s, mv->strSubVer, sizeof(mv->strSubVer));
 	ser_u32(s, mv->nStartingHeight);
+	if (mv->nVersion >= 70001) {
+		ser_bool(s, mv->bRelay);
+	}
 
 	return s;
 }

--- a/lib/serialize.c
+++ b/lib/serialize.c
@@ -36,6 +36,11 @@ void ser_u64(cstring *s, uint64_t v_)
 	cstr_append_buf(s, &v, sizeof(v));
 }
 
+void ser_bool(cstring *s, bool v_)
+{
+	cstr_append_c(s, v_?1:0);
+}
+
 void ser_varlen(cstring *s, uint32_t vlen)
 {
 	unsigned char c;
@@ -147,6 +152,17 @@ bool deser_u64(uint64_t *vo, struct const_buffer *buf)
 		return false;
 
 	*vo = le64toh(v);
+	return true;
+}
+
+bool deser_bool(bool *vo, struct const_buffer *buf)
+{
+	uint8_t v;
+
+	if (!deser_bytes(&v, buf, sizeof(v)))
+		return false;
+
+	*vo = (0 != v);
 	return true;
 }
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -13,6 +13,7 @@ fileio
 hashtab
 hex
 keyset
+message
 parr
 script
 script-parse

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,11 +19,11 @@ noinst_LIBRARIES= libtest.a
 libtest_a_SOURCES= libtest.h libtest.c
 
 noinst_PROGRAMS	= clist cstr hex hashtab base58 fileio util keyset bloom \
-		  parr script-parse tx block blockfile blkdb script \
+		  message parr script-parse tx block blockfile blkdb script \
 		  tx-valid wallet wallet-basics chain-verf
 
 TESTS		= clist cstr hex hashtab base58 fileio util keyset bloom \
-		  parr script-parse tx block blockfile blkdb script \
+		  message parr script-parse tx block blockfile blkdb script \
 		  tx-valid wallet wallet-basics chain-verf
 
 COMMON_LDADD	= libtest.a ../lib/libccoin.a \
@@ -41,6 +41,7 @@ fileio_LDADD		= $(COMMON_LDADD)
 hex_LDADD		= $(COMMON_LDADD)
 hashtab_LDADD		= $(COMMON_LDADD)
 keyset_LDADD		= $(COMMON_LDADD)
+message_LDADD		= $(COMMON_LDADD)
 parr_LDADD		= $(COMMON_LDADD)
 script_LDADD		= $(COMMON_LDADD)
 script_parse_LDADD	= $(COMMON_LDADD)

--- a/test/message.c
+++ b/test/message.c
@@ -1,0 +1,153 @@
+/* Copyright 2015 BitPay, Inc.
+ * Copyright 2015 Duncan Tebbs
+ * Distributed under the MIT/X11 software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include <assert.h>
+#include <ccoin/message.h>
+
+static void check_buffer(const cstring *buffer,
+                         const void *expected_data,
+                         const size_t expected_size)
+{
+    if (buffer->len != expected_size) {
+        fprintf(stderr, "Expected msg size: %d, saw size: %d\n",
+                (int )expected_size, (int )(buffer->len));
+    }
+    assert(buffer->len == expected_size);
+
+    if (0 != memcmp(buffer->str, expected_data, expected_size)) {
+        const uint8_t *buffer_data = (const uint8_t *)buffer->str;
+        const uint8_t *expect = (const uint8_t *)expected_data;
+        int i;
+
+        for (i = 0 ; i < expected_size ; ++i) {
+            fprintf(stderr, "%03d: expected: %02x saw: %02x",
+                    i, expect[i], buffer_data[i]);
+            if (buffer_data[i] != expect[i]) {
+                fprintf(stderr, " ***\n");
+            } else {
+                fputs("\n", stderr);
+            }
+        }
+    }
+
+    assert(0 == memcmp(buffer->str, expected_data, expected_size));
+}
+
+static void serialize_version_and_check(const struct msg_version *mv,
+                                        const void *expected_data,
+                                        const size_t expected_size)
+{
+    cstring *s = ser_msg_version(mv);
+    check_buffer(s, expected_data, expected_size);
+    cstr_free(s, true);
+}
+
+static void test_version()
+{
+    /*
+    Example from protocol documentation wiki:
+     https://en.bitcoin.it/wiki/Protocol_documentation
+
+    Message Header:
+      F9 BE B4 D9                                - Main network magic bytes
+      76 65 72 73 69 6F 6E 00 00 00 00 00        - "version" command
+      64 00 00 00                                - Payload is 100 bytes long
+      3B 64 8D 5A                                - payload checksum
+
+    Version message:
+     24: 62 EA 00 00                             - protocol version 60002
+     28: 01 00 00 00 00 00 00 00                 - 1 (NODE_NETWORK services)
+     36: 11 B2 D0 50 00 00 00 00                 - Tue Dec 18 10:12:33 PST 2012
+     44: 01 00 00 00 00 00 00 00
+     52: 00 00 00 00 00 00 00 00 00 00 FF FF 00 00 00 00
+     68: 00 00                                   - Recipient address info
+     70: 01 00 00 00 00 00 00 00
+     78: 00 00 00 00 00 00 00 00 00 00 FF FF 00 00 00 00
+     94: 00 00                                   - Sender address info
+     96: 3B 2E B3 5D 8C E6 17 65                 - Node ID
+    104: 0F 2F 53 61 74 6F 73 68 69 3A 30 2E 37 2E 32 2F
+                                                 - "/Satoshi:0.7.2/" sub-version
+    120: C0 3E 03 00                             - Last block: #212672
+    */
+
+    /*
+    NOTE: wiki entry is broken (as of Sept 22, 2015).  The data above
+    is correct if addrFrom.nServices = 1 (from offset 70), but in the
+    raw data, addrFrom.nServices = 0,
+    */
+
+    const uint8_t expectIP[16] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00
+    };
+
+    {
+        const uint8_t expected[] = {
+            0x62, 0xea, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x11, 0xb2, 0xd0, 0x50,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x3b, 0x2e, 0xb3, 0x5d, 0x8c, 0xe6, 0x17, 0x65,
+            0x0f, 0x2f, 0x53, 0x61, 0x74, 0x6f, 0x73, 0x68,
+            0x69, 0x3a, 0x30, 0x2e, 0x37, 0x2e, 0x32, 0x2f,
+            0xc0, 0x3e, 0x03, 0x00
+        };
+
+        /* serialize */
+        {
+            struct msg_version mv;
+
+            msg_version_init(&mv);
+            mv.nVersion = 60002;
+            mv.nServices = 1;
+            mv.nTime = 0x50d0b211;
+            mv.addrTo.nServices = 1;
+            mv.addrTo.ip[10] = mv.addrTo.ip[11] = 255;
+            mv.addrFrom.nServices = 0;
+            mv.addrFrom.ip[10] = mv.addrFrom.ip[11] = 255;
+            mv.nonce = 0x6517e68c5db32e3b;
+            strcpy(mv.strSubVer, "/Satoshi:0.7.2/");
+            mv.nStartingHeight = 212672;
+
+            serialize_version_and_check(&mv, expected, sizeof(expected));
+            msg_version_free(&mv);
+        }
+
+        /* deserialize */
+        {
+            struct msg_version mv;
+            msg_version_init(&mv);
+
+            struct const_buffer buf = { expected, sizeof(expected) };
+            assert(deser_msg_version(&mv, &buf));
+
+            assert(60002 == mv.nVersion);
+            assert(1 == mv.nServices);
+            assert(0x50d0b211 == mv.nTime);
+            assert(1 == mv.addrTo.nServices);
+            assert(0 == memcmp(mv.addrTo.ip, expectIP, sizeof(expectIP)));
+            assert(0 == mv.addrFrom.nServices);
+            assert(0 == memcmp(mv.addrFrom.ip, expectIP, sizeof(expectIP)));
+            assert(0x6517e68c5db32e3b == mv.nonce);
+            assert(0 == strcmp(mv.strSubVer, "/Satoshi:0.7.2/"));
+            assert(212672 == mv.nStartingHeight);
+
+            msg_version_free(&mv);
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    test_version();
+
+    return 0;
+}


### PR DESCRIPTION
Two commits:

1. Add a test program for message (de)serializing.  The full set of tests for existing code can be added independently.  The intention here is to create a place where tests can be added going forward (in particular for the following change).  For now I'm comparing against example data from the protocol wiki to test the 'version' message.  Other message types may need a different approach.

2. Added the 'relay' field, including related message tests.


