### PR TITLE
configure.ac: supress OpenSSL deprecation warnings on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install jansson; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libevent; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install argp-standalone; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install openssl; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$COVERAGE_STATS" = "true" ]; then brew install lcov; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$USE_VALGRIND" = "true" ]; then brew install valgrind; fi
   - if [ "$COVERAGE_STATS" = "true" ]; then gem install coveralls-lcov; fi

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,8 @@ case "${host}" in
 		#ifndef O_LARGEFILE
 		# define O_LARGEFILE 0
 		#endif])
+		CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
+		LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
 		;;
 esac
 

--- a/include/ccoin/compat.h
+++ b/include/ccoin/compat.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-#ifndef HAVE_FDATASYNC
+#if defined(__APPLE__) || !defined(HAVE_FDATASYNC)
 static inline int fdatasync(int fd)
 {
 #ifdef WIN32

--- a/src/brd.c
+++ b/src/brd.c
@@ -9,6 +9,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
+#if defined(__APPLE__)
+# include <sys/uio.h>
+#endif
 #include <fcntl.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -29,6 +32,11 @@
 #include <ccoin/hexcode.h>
 #include "peerman.h"
 #include "brd.h"
+
+#if defined(__GNUC__)
+/* For add_orphan */
+# pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 
 struct bp_hashtab *settings;
 const struct chain_info *chain = NULL;


### PR DESCRIPTION
I'm not familiar with autoconf so there may be a more correct way to do this.