### PR TITLE
travis: Enable code coverage with Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   global:
     - MAKEJOBS=-j3
     - RUN_TESTS=true
+    - COVERAGE_STATS=true
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
 
 cache:
@@ -26,6 +27,7 @@ addons:
       - libssl-dev
       - libjansson-dev
       - libevent-dev
+      - lcov
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
@@ -34,16 +36,23 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install jansson; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libevent; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install argp-standalone; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lcov; fi
+  - if [ "$COVERAGE_STATS" = "true" ]; then gem install coveralls-lcov; fi
 
 before_script:
   - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
   - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
+  - if [ "$COVERAGE_STATS" = "true" ]; then COVERAGE_OPT="--enable-coverage"; fi
 
 script:
   - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
   - PICOCOIN_CONFIG_ALL="--prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-  - ./configure --cache-file=config.cache $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
+  - ./configure --cache-file=config.cache $COVERAGE_OPT $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
   - make -s $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL ; false )
   - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
   - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS distcheck; fi
+  - if [ "$COVERAGE_STATS" = "true" ]; then make $MAKEJOBS check; fi
 
+after_success:
+  - if [ "$COVERAGE_STATS" = "true" ]; then lcov --compat-libtool --directory . --capture --output-file coverage.info; fi
+  - if [ "$COVERAGE_STATS" = "true" ]; then coveralls-lcov coverage.info; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 #Picocoin
 
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/jgarzik/picocoin/master/COPYING) [![Build Status](https://travis-ci.org/jgarzik/picocoin.svg?branch=master)](https://travis-ci.org/jgarzik/picocoin) [![Coverage Status](https://coveralls.io/repos/github/jgarzik/picocoin/badge.svg?branch=master)](https://coveralls.io/github/jgarzik/picocoin?branch=master)
 
 Tiny bitcoin library, with lightweight client and utils
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,24 @@ dnl -----------------
 dnl Configure options
 dnl -----------------
 
+dnl Coverage
+AC_MSG_CHECKING([whether to code coverage])
+AC_ARG_ENABLE([coverage],
+	[AS_HELP_STRING([--enable-coverage],[generate code coverage instrumentation])],
+	[],
+	[enable_coverage=no])
+AC_MSG_RESULT([$enable_coverage])
+
+AS_IF([test "$enable_coverage" = "yes"], [
+	AC_PATH_PROG(GCOV, gcov, no)
+	AS_IF([test "$GCOV" = "no"], [
+		AC_MSG_ERROR(gcov tool is not available)])
+	AC_PATH_PROG(LCOV, lcov, no)
+	AS_IF([test "$LCOV" = "no"], [
+		AC_MSG_ERROR(lcov tool is not installed)])
+	CFLAGS="$CFLAGS -O0 -fprofile-arcs -ftest-coverage"
+])
+
 dnl --------------------------
 dnl autoconf output generation
 dnl --------------------------
@@ -103,4 +121,3 @@ AC_CONFIG_FILES([
 	test/Makefile
 	])
 AC_OUTPUT
-


### PR DESCRIPTION
Hi,

This pull request adds some coverage statistics via Coveralls.

The picocoin Github repo must first be linked to Coveralls (https://coveralls.io) then the next Travis build with generate and upload coverage status to Coveralls.....and put a pretty little badge on the README :-)

Current coverage is about 77%. https://coveralls.io/builds/5381294
