### PR TITLE
travis: Add --enable-valgrind option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - MAKEJOBS=-j3
     - RUN_TESTS=true
     - COVERAGE_STATS=true
+    - USE_VALGRIND=false
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
 
 cache:
@@ -28,6 +29,7 @@ addons:
       - libjansson-dev
       - libevent-dev
       - lcov
+      - valgrind
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
@@ -36,23 +38,24 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install jansson; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libevent; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install argp-standalone; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lcov; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$COVERAGE_STATS" = "true" ]; then brew install lcov; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$USE_VALGRIND" = "true" ]; then brew install valgrind; fi
   - if [ "$COVERAGE_STATS" = "true" ]; then gem install coveralls-lcov; fi
 
 before_script:
   - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
   - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
   - if [ "$COVERAGE_STATS" = "true" ]; then COVERAGE_OPT="--enable-coverage"; fi
+  - if [ "$USE_VALGRIND" = "true" ]; then VALGRIND_OPT="--enable-valgrind"; fi
 
 script:
   - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
   - PICOCOIN_CONFIG_ALL="--prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-  - ./configure --cache-file=config.cache $COVERAGE_OPT $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
+  - ./configure --cache-file=config.cache $COVERAGE_OPT $VALGRIND_OPT $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
   - make -s $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL ; false )
   - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
   - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS distcheck; fi
-  - if [ "$COVERAGE_STATS" = "true" ]; then make $MAKEJOBS check; fi
+  - if [ "$COVERAGE_STATS" = "true" ] || [ "$USE_VALGRIND" = "true" ]; then make $MAKEJOBS check; fi
 
 after_success:
-  - if [ "$COVERAGE_STATS" = "true" ]; then lcov --compat-libtool --directory . --capture --output-file coverage.info; fi
-  - if [ "$COVERAGE_STATS" = "true" ]; then coveralls-lcov coverage.info; fi
+  - if [ "$COVERAGE_STATS" = "true" ]; then lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info; fi

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,21 @@ AS_IF([test "$enable_coverage" = "yes"], [
 	CFLAGS="$CFLAGS -O0 -fprofile-arcs -ftest-coverage"
 ])
 
+dnl Valgrind
+AC_MSG_CHECKING([whether to use valgrind])
+AC_ARG_ENABLE([valgrind],
+	[AS_HELP_STRING([--enable-valgrind],[Use valgrind when running unit tests])],
+	[],
+	[enable_valgrind=no])
+AC_MSG_RESULT([$enable_valgrind])
+
+AS_IF([test "$enable_valgrind" = "yes"], [
+	AC_PATH_PROG(VALGRIND, valgrind, no)
+	AS_IF([test "$VALGRIND" = "no"], [
+		AC_MSG_ERROR(valgrind tool is not installed)])
+])
+AM_CONDITIONAL(ENABLE_VALGRIND, [test "$enable_valgrind" = "yes"])
+
 dnl --------------------------
 dnl autoconf output generation
 dnl --------------------------

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,7 @@
-
+if ENABLE_VALGRIND
+    TESTS_ENVIRONMENT=valgrind --quiet --leak-check=full --error-exitcode=1
+endif
+ 
 AM_CPPFLAGS	= -DTEST_SRCDIR=\"$(top_srcdir)/test\" \
 		  -I$(top_srcdir)/include
 
@@ -29,26 +32,26 @@ TESTS		= clist cstr hex hdkeys hashtab base58 fileio util keyset bloom \
 COMMON_LDADD	= libtest.a ../lib/libccoin.a \
 		  @CRYPTO_LIBS@ @JANSSON_LIBS@ @MATH_LIBS@
 
-base58_LDADD		= $(COMMON_LDADD)
-blkdb_LDADD		= $(COMMON_LDADD)
-block_LDADD		= $(COMMON_LDADD)
-blockfile_LDADD		= $(COMMON_LDADD)
-bloom_LDADD		= $(COMMON_LDADD)
+base58_LDADD        = $(COMMON_LDADD)
+blkdb_LDADD         = $(COMMON_LDADD)
+block_LDADD         = $(COMMON_LDADD)
+blockfile_LDADD 	= $(COMMON_LDADD)
+bloom_LDADD         = $(COMMON_LDADD)
 chain_verf_LDADD	= $(COMMON_LDADD)
-clist_LDADD		= $(COMMON_LDADD)
-cstr_LDADD		= $(COMMON_LDADD)
+clist_LDADD         = $(COMMON_LDADD)
+cstr_LDADD		    = $(COMMON_LDADD)
 fileio_LDADD		= $(COMMON_LDADD)
-hex_LDADD		= $(COMMON_LDADD)
+hex_LDADD           = $(COMMON_LDADD)
 hashtab_LDADD		= $(COMMON_LDADD)
 hdkeys_LDADD		= $(COMMON_LDADD)
 keyset_LDADD		= $(COMMON_LDADD)
 message_LDADD		= $(COMMON_LDADD)
-parr_LDADD		= $(COMMON_LDADD)
+parr_LDADD		    = $(COMMON_LDADD)
 script_LDADD		= $(COMMON_LDADD)
 script_parse_LDADD	= $(COMMON_LDADD)
-tx_LDADD		= $(COMMON_LDADD)
+tx_LDADD            = $(COMMON_LDADD)
 tx_valid_LDADD		= $(COMMON_LDADD)
-util_LDADD		= $(COMMON_LDADD)
+util_LDADD		    = $(COMMON_LDADD)
 wallet_LDADD		= $(COMMON_LDADD)
 wallet_basics_LDADD	= $(COMMON_LDADD)
 


### PR DESCRIPTION
Added `--enable-valgrind` option but it is currently disabled in `.travis.yml` config (`USE_VALGRIND=false`) until memory leak reported in #58 is fixed. This memory leak causes Valgrind memory check to fail.

When/if the memory leak is fixed the Valgrind option may be enabled and all tests will then pass on travis.