### PR TITLE
ccoin: Fix memory leak in script_eval.c

### DIFF
--- a/lib/bignum.c
+++ b/lib/bignum.c
@@ -13,7 +13,7 @@ void bn_setvch(mpz_t vo, const void *data_, size_t data_len)
 
 	mpz_import(vo, data_len, -1, 1, 1, 0, data);
 
-	if (data[data_len - 1] & 0x80) {
+	if ((data_len > 0) && (data[data_len - 1] & 0x80)) {
 		mpz_clrbit(vo, mpz_sizeinbase(vo, 2) - 1);
 		mpz_neg(vo, vo);
 	}

--- a/lib/script_eval.c
+++ b/lib/script_eval.c
@@ -506,8 +506,8 @@ static bool bp_script_eval(parr *stack, const cstring *script,
 			struct buffer *vch1 = stack_take(stack, -6);
 			struct buffer *vch2 = stack_take(stack, -5);
 			parr_remove_range(stack, stack->len - 6, 2);
-			stack_push(stack, vch1);
-			stack_push(stack, vch2);
+			stack_push_nocopy(stack, vch1);
+			stack_push_nocopy(stack, vch2);
 			break;
 		}
 


### PR DESCRIPTION
Hi,

This pull request fixes #58.
It was a simple fix in the end but quite tricky to find.

Valgrind is now enabled in the `.travis.xml` config. However, there seems to be differences between the Linux libtool and OSX libtool.
OSX does not like:
```
TESTS_ENVIRONMENT=libtool --mode=execute valgrind --quiet --leak-check=full --error-exitcode=1
```
As a result the Valgrind check is currently only performed on the Linux build on Travis.