### PR TITLE
ccoin: Added Electric Fence malloc debugger checks and fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,19 @@ AS_IF([test "$enable_valgrind" = "yes"], [
 ])
 AM_CONDITIONAL(ENABLE_VALGRIND, [test "$enable_valgrind" = "yes"])
 
+dnl Electric Fence
+AC_MSG_CHECKING([whether to enable electric fence (www.perens.com)])
+AC_ARG_ENABLE([efence],
+	[AS_HELP_STRING([--enable-efence],[Enable Electric Fence Malloc Debugger])],
+	[],
+	[enable_efence=no])
+AC_MSG_RESULT([$enable_efence])
+
+AS_IF([test "$enable_efence" = "yes"], [
+	AC_CHECK_LIB(efence, memalign,,
+	  [AC_MSG_ERROR([Missing required libefence])])
+])
+
 dnl --------------------------
 dnl autoconf output generation
 dnl --------------------------

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -23,6 +23,8 @@ bool buffer_equal(const void *a_, const void *b_)
 
 	if (a->len != b->len)
 		return false;
+	if (a->len == 0)
+		return true;
 	return memcmp(a->p, b->p, a->len) == 0;
 }
 
@@ -38,17 +40,19 @@ void buffer_free(void *struct_buffer)
 
 struct buffer *buffer_copy(const void *data, size_t data_len)
 {
-	struct buffer *buf;
-	buf = malloc(sizeof(*buf));
+	struct buffer *buf = calloc(1, sizeof(struct buffer));
+
 	if (!buf)
 		goto err_out;
 
-	buf->p = malloc(data_len);
-	if (!buf->p)
-		goto err_out_free;
+	if (data_len > 0) {
+		buf->p = malloc(data_len);
+		if (!buf->p)
+			goto err_out_free;
 
-	memcpy(buf->p, data, data_len);
-	buf->len = data_len;
+		memcpy(buf->p, data, data_len);
+		buf->len = data_len;
+	} else buf->p = NULL;
 
 	return buf;
 

--- a/lib/cstr.c
+++ b/lib/cstr.c
@@ -136,6 +136,8 @@ bool cstr_equal(const cstring *a, const cstring *b)
 		return false;
 	if (a->len != b->len)
 		return false;
+	if (a->len == 0)
+		return true;
 	return (memcmp(a->str, b->str, a->len) == 0);
 }
 

--- a/lib/script_eval.c
+++ b/lib/script_eval.c
@@ -634,8 +634,7 @@ static bool bp_script_eval(parr *stack, const cstring *script,
 				goto out;
 			struct buffer *vch1 = stacktop(stack, -2);
 			struct buffer *vch2 = stacktop(stack, -1);
-			bool fEqual = ((vch1->len == vch2->len) &&
-				      memcmp(vch1->p, vch2->p, vch1->len) == 0);
+			bool fEqual = buffer_equal(vch1, vch2);
 			// OP_NOTEQUAL is disabled because it would be too easy to say
 			// something like n != 1 and have some wiseguy pass in 1 with extra
 			// zero bytes after it (numerically, 0x01 == 0x0001 == 0x000001)
@@ -1032,7 +1031,6 @@ bool bp_script_verify(const cstring *scriptSig, const cstring *scriptPubKey,
 {
 	bool rc = false;
 	parr *stack = parr_new(0, buffer_free);
-	cstring *pubkey2 = NULL;
 	parr *stackCopy = NULL;
 
 	if (!bp_script_eval(stack, scriptSig, txTo, nIn, flags, nHashType))
@@ -1082,8 +1080,6 @@ bool bp_script_verify(const cstring *scriptSig, const cstring *scriptPubKey,
 
 out:
 	parr_free(stack, true);
-	if (pubkey2)
-		cstr_free(pubkey2, true);
 	if (stackCopy)
 		parr_free(stackCopy, true);
 	return rc;
@@ -1109,4 +1105,3 @@ bool bp_verify_sig(const struct bp_utxo *txFrom, const struct bp_tx *txTo,
 	return bp_script_verify(txin->scriptSig, txout->scriptPubKey,
 				txTo, nIn, flags, nHashType);
 }
-

--- a/test/parr.c
+++ b/test/parr.c
@@ -14,13 +14,15 @@ static void test_basic(void)
 
 	pa = parr_new(0, free);
 	assert(pa != NULL);
-	assert(pa->data != NULL);
+	assert(pa->data == NULL);
 	assert(pa->len == 0);
-	assert(pa->alloc > 0);
+	assert(pa->alloc == 0);
 
 	rc = parr_add(pa, strdup("foo"));
 	assert(rc == true);
+	assert(pa->data != NULL);
 	assert(pa->len == 1);
+	assert(pa->alloc > 0);
 
 	rc = parr_add(pa, strdup("bar"));
 	assert(rc == true);
@@ -61,9 +63,9 @@ static void test_resize(void)
 
 	pa = parr_new(0, free);
 	assert(pa != NULL);
-	assert(pa->data != NULL);
+	assert(pa->data == NULL);
 	assert(pa->len == 0);
-	assert(pa->alloc > 0);
+	assert(pa->alloc == 0);
 
 	rc = parr_add(pa, strdup("foo"));
 	rc = parr_add(pa, strdup("bar"));


### PR DESCRIPTION
Hi,

When debugging the memory leak reported in #58 I used the Valgrind and Electric Fence tools. 

A few tests caused the following error:
```
ElectricFence Aborting: Allocating 0 bytes, probably a bug.
```

These error messages were caused by several `malloc(0)`'s in the code which isn't actually a bug. Thinking this may be the cause of the leak I fixed all the Electric Fence error messages. It turns out this wasn't the cause of the leak but I've the code written now so why waste it.
With these changes memory is now allocated to pointer arrays and buffers only if and when it is needed. Also, there is now a `--enable-efence` option added for local testing and future memory allocation debugging.

All tests pass:
```
make[3]: Entering directory '/home/aido/picocoin/test'
PASS: clist
PASS: cstr
PASS: hex
PASS: hdkeys
PASS: hashtab
PASS: base58
PASS: fileio
PASS: util
PASS: keyset
PASS: bloom
PASS: message
PASS: parr
PASS: script-parse
PASS: tx
PASS: block
PASS: blockfile
PASS: blkdb
PASS: script
PASS: tx-valid
PASS: wallet
PASS: wallet-basics
PASS: chain-verf
make[4]: Entering directory '/home/aido/picocoin/test'
make[4]: Nothing to be done for 'all'.
make[4]: Leaving directory '/home/aido/picocoin/test'
============================================================================
Testsuite summary for picocoin 0.1git
============================================================================
# TOTAL: 22
# PASS:  22
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

```
aido@vm:~/picocoin$ cat ./test/chain-verf.log
chain-verf: validating mainnet chainfile /home/aido/picocoin/bootstrap.dat (+script)
chain-verf: spend block @ 0
chain-verf: spend block @ 5000
.
.
.
chain-verf: spend block @ 145000
chain-verf: spend block @ 150000
chain-verf: 150001 records validated
```



