### PR TITLE
ccoin: Fixes #67: Hurricane Electric uses block 2001:470::, not 2011:…

### DIFF
--- a/lib/net.c
+++ b/lib/net.c
@@ -217,7 +217,7 @@ void bn_group(unsigned char *group, unsigned int *group_len,
 		bits = 4;
 	}
 
-	else if (ipaddr[GB(15)] == 0x20 && ipaddr[GB(14)] == 0x11 &&
+	else if (ipaddr[GB(15)] == 0x20 && ipaddr[GB(14)] == 0x01 &&
 		 ipaddr[GB(13)] == 0x04 && ipaddr[GB(12)] == 0x70)
 		bits = 36;
 


### PR DESCRIPTION
See #67 and https://github.com/bitcoin/bitcoin/commit/a5e685bcf8eea088ba2eea544dcf2b0ac29ff6cc
