### PR TITLE
configure.ac: explicitly include /usr/local libs (fixes build errors in latest xcode)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,8 @@ case "${host}" in
 		#ifndef O_LARGEFILE
 		# define O_LARGEFILE 0
 		#endif])
-		CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
-		LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
+		CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include -I/usr/local/include"
+		LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib -L/usr/local/lib"
 		;;
 esac
 


### PR DESCRIPTION
After upgrading OS X and Xcode I suddenly had to explicity add `/usr/local` paths in order to pick up brew versions of gmp and other libs.