### PR TITLE
ccoin: Add a simple logging framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "external/secp256k1"]
 	path = external/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1.git
+	ignore = dirty

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
       - libltdl-dev
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew upgrade; fi
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install jansson; fi

--- a/include/ccoin/Makefile.am
+++ b/include/ccoin/Makefile.am
@@ -20,6 +20,7 @@ ccoininclude_HEADERS = \
 	hdkeys.h	\
 	hexcode.h	\
 	key.h		\
+	log.h		\
 	mbr.h		\
 	message.h	\
 	parr.h		\

--- a/include/ccoin/log.h
+++ b/include/ccoin/log.h
@@ -1,0 +1,48 @@
+#ifndef __LIBCCOIN_LOG_H__
+#define __LIBCCOIN_LOG_H__
+/* Copyright 2012 exMULTI, Inc.
+ * Distributed under the MIT/X11 software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include <stdio.h>                      // for fprintf
+#include <stdbool.h>                    // for bool
+
+#define log_info(LOGMESSAGE, ...)						\
+            if ( log_state->logtofile ) {					\
+                fprintf(log_state->stream, "%s" LOGMESSAGE "\n",		\
+                    str_timenow(),						\
+                    ##__VA_ARGS__);						\
+            } else {								\
+                fprintf(log_state->stream, LOGMESSAGE "\n", ##__VA_ARGS__); }
+
+#define log_error(LOGMESSAGE, ...)						\
+            fprintf(stderr, LOGMESSAGE "\n", ##__VA_ARGS__);			\
+            if ( log_state->logtofile ) {					\
+                fprintf(log_state->stream, "%s" LOGMESSAGE "\n",		\
+                    str_timenow(),						\
+                    ##__VA_ARGS__); }
+
+#define log_debug(LOGMESSAGE, ...)						\
+            if ( log_state->debug ) {						\
+                log_info(LOGMESSAGE, ##__VA_ARGS__); }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct logging {
+	FILE *stream;
+	bool logtofile;
+	bool debug;
+};
+
+extern struct logging *log_state;
+
+char *str_timenow();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LIBCCOIN_LOG_H__ */

--- a/include/ccoin/net/net.h
+++ b/include/ccoin/net/net.h
@@ -36,6 +36,8 @@ enum netcmds {
 	NC_STOP,
 };
 
+struct net_settings *net_settings;
+
 struct net_child_info {
 	int			read_fd;
 	int			write_fd;
@@ -52,8 +54,6 @@ struct net_child_info {
 	uint64_t		*instance_nonce;
 
 	bool			running;
-	bool			debugging;
-	FILE			*plog;
 
 	bool (*inv_block_process)(bu256_t *hash);
 	bool (*block_process)(struct bp_block *block,
@@ -97,13 +97,11 @@ struct net_engine {
 	int	par_read;
 	int	par_write;
 	pid_t	child;
-	bool	debugging;
-	FILE	*plog;
 	void (*network_child_process)(int read_fd, int write_fd);
 
 };
 
-struct net_engine *neteng_new_start(void (*network_child)(int read_fd, int write_fd), bool debugging, FILE *plog);
+struct net_engine *neteng_new_start(void (*network_child)(int read_fd, int write_fd));
 
 static void nc_conn_kill(struct nc_conn *conn);
 static bool nc_conn_read_enable(struct nc_conn *conn);

--- a/include/ccoin/net/peerman.h
+++ b/include/ccoin/net/peerman.h
@@ -53,7 +53,6 @@ struct peer_manager {
 	clist		*addrlist;	/* of struct bp_address */
 };
 
-extern void peerman_debug(bool debugging);
 extern void peerman_free(struct peer_manager *peers);
 extern struct peer_manager *peerman_read(void *peer_file);
 extern struct peer_manager *peerman_seed(bool use_dns);

--- a/include/ccoin/script.h
+++ b/include/ccoin/script.h
@@ -258,7 +258,7 @@ extern bool is_bsp_multisig(parr *ops);
 
 static inline bool is_bsp_pushdata(enum opcodetype op)
 {
-	return (0 <= op && op <= OP_PUSHDATA4);
+	return (op <= OP_PUSHDATA4);
 }
 
 static inline bool is_bsp_p2sh(struct const_buffer *buf)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -30,6 +30,7 @@ libccoin_la_SOURCES=	\
 	key.c		\
 	keyset.c	\
 	keystore.c	\
+	log.c		\
 	mbr.c		\
 	memmem.c	\
 	message.c	\

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,0 +1,21 @@
+/* Copyright 2012 exMULTI, Inc.
+ * Distributed under the MIT/X11 software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include <ccoin/log.h>
+
+#include <time.h>                       // for localtime, strftime, time, etc
+
+char *str_timenow() {
+    static char time_buf[22];
+    time_t now;
+    struct tm *tm_now;
+
+    time(&now);
+    tm_now = localtime(&now);
+
+    strftime(time_buf, 21, "%F %T ", tm_now);
+
+    return time_buf;
+}

--- a/lib/net/net.c
+++ b/lib/net/net.c
@@ -585,7 +585,7 @@ static bool nc_conn_start(struct nc_conn *conn)
 	conn->fd = socket(conn->ipv4 ? AF_INET : AF_INET6,
 			  SOCK_STREAM, IPPROTO_TCP);
 	if (conn->fd < 0) {
-		log_error("net: socket %s %s",
+		log_error("net: socket %s: %s",
 			conn->addr_str,
 			strerror(errno));
 		return false;
@@ -595,7 +595,7 @@ static bool nc_conn_start(struct nc_conn *conn)
 	int flags = fcntl(conn->fd, F_GETFL, 0);
 	if ((flags < 0) ||
 	    (fcntl(conn->fd, F_SETFL, flags | O_NONBLOCK) < 0)) {
-		log_error("net: socket fcntl %s %s",
+		log_error("net: socket fcntl %s: %s",
 			conn->addr_str,
 			strerror(errno));
 		return false;
@@ -630,7 +630,7 @@ static bool nc_conn_start(struct nc_conn *conn)
 	/* initiate TCP connection */
 	if (connect(conn->fd, saddr, saddr_len) < 0) {
 		if (errno != EINPROGRESS) {
-			log_error("net: socket connect %s %s",
+			log_error("net: socket connect %s: %s",
 				conn->addr_str,
 				strerror(errno));
 			return false;
@@ -972,7 +972,8 @@ static void pipwr(int fd, const void *buf, size_t len)
 		ssize_t wrc;
 		wrc = write(fd, buf, len);
 		if (wrc < 0) {
-			perror("pipe write");
+			log_error("net: pipe write: %s",
+			strerror(errno));
 			return;
 		}
 
@@ -1006,7 +1007,8 @@ static enum netcmds readcmd(int fd, int timeout_secs)
 	int prc = poll(&pfd, 1, timeout_secs ? timeout_secs * 1000 : -1);
 
 	if (prc < 0) {
-		perror("pipe poll");
+		log_error("net: pipe poll: %s",
+			strerror(errno));
 		return NC_ERR;
 	}
 	if (prc == 0)
@@ -1015,7 +1017,8 @@ static enum netcmds readcmd(int fd, int timeout_secs)
 	uint8_t v;
 	ssize_t rrc = read(fd, &v, 1);
 	if (rrc < 0) {
-		perror("pipe read");
+		log_error("net: pipe read: %s",
+			strerror(errno));
 		return NC_ERR;
 	}
 	if (rrc != 1)

--- a/lib/net/net.c
+++ b/lib/net/net.c
@@ -12,6 +12,7 @@
 #include <ccoin/coredefs.h>             // for ::CADDR_TIME_VERSION, etc
 #include <ccoin/cstr.h>                 // for cstring, cstr_free
 #include <ccoin/hashtab.h>              // for bp_hashtab_size
+#include <ccoin/log.h>                  // for log_info, log_debug, etc
 #include <ccoin/parr.h>                 // for parr, parr_idx, parr_add, etc
 #include <ccoin/util.h>                 // for MIN
 
@@ -35,8 +36,6 @@
 #include <sys/socket.h>                 // for AF_INET, AF_INET6, connect, etc
 #include <sys/uio.h>                    // for iovec, writev
 #endif
-
-struct net_settings *net_settings;
 
 void net_set(struct net_settings *_net_settings)
 {
@@ -205,11 +204,11 @@ static bool nc_msg_version(struct nc_conn *conn)
 	if (!deser_msg_version(&mv, &buf))
 		goto out;
 
-	if (conn->nci->debugging) {
+	if (log_state->debug) {
 		char fromstr[64], tostr[64];
 		bn_address_str(fromstr, sizeof(fromstr), mv.addrFrom.ip);
 		bn_address_str(tostr, sizeof(tostr), mv.addrTo.ip);
-		fprintf(conn->nci->plog, "net: %s version(%u, 0x%llx, %lld, To:%s, From:%s, %s, %u)\n",
+		log_debug("net: %s version(%u, 0x%llx, %lld, To:%s, From:%s, %s, %u)",
 			conn->addr_str,
 			mv.nVersion,
 			(unsigned long long) mv.nServices,
@@ -251,14 +250,14 @@ static bool nc_msg_addr(struct nc_conn *conn)
 
 	unsigned int i;
 	time_t cutoff = time(NULL) - (7 * 24 * 60 * 60);
-	if (conn->nci->debugging) {
+	if (log_state->debug) {
 		unsigned int old = 0;
 		for (i = 0; i < ma.addrs->len; i++) {
 			struct bp_address *addr = parr_idx(ma.addrs, i);
 			if (addr->nTime < cutoff)
 				old++;
 		}
-		fprintf(conn->nci->plog, "net: %s addr(%zu addresses, %u old)\n",
+		log_debug("net: %s addr(%zu addresses, %u old)",
 			conn->addr_str, ma.addrs->len, old);
 	}
 
@@ -287,9 +286,7 @@ static bool nc_msg_verack(struct nc_conn *conn)
 		return false;
 	conn->seen_verack = true;
 
-	if (conn->nci->debugging)
-		fprintf(conn->nci->plog, "net: %s verack\n",
-			conn->addr_str);
+	log_debug("net: %s verack", conn->addr_str);
 
 	/*
 	 * When a connection attempt is made, the peer is deleted
@@ -340,7 +337,7 @@ static bool nc_msg_inv(struct nc_conn *conn)
 	if (!deser_msg_vinv(&mv, &buf))
 		goto out;
 
-	if (conn->nci->debugging && mv.invs && mv.invs->len == 1) {
+	if (log_state->debug && mv.invs && mv.invs->len == 1) {
 		struct bp_inv *inv = parr_idx(mv.invs, 0);
 		char hexstr[BU256_STRSZ];
 		bu256_hex(hexstr, &inv->hash);
@@ -352,11 +349,11 @@ static bool nc_msg_inv(struct nc_conn *conn)
 		default: sprintf(typestr, "unknown 0x%x", inv->type); break;
 		}
 
-		fprintf(conn->nci->plog, "net: %s inv %s %s\n",
+		log_debug("net: %s inv %s %s",
 			conn->addr_str, typestr, hexstr);
 	}
-	else if (conn->nci->debugging && mv.invs) {
-		fprintf(conn->nci->plog, "net: %s inv (%zu sz)\n",
+	else if (mv.invs) {
+		log_debug("net: %s inv (%zu sz)",
 			conn->addr_str, mv.invs->len);
 	}
 
@@ -411,16 +408,12 @@ static bool nc_msg_block(struct nc_conn *conn)
 	char hexstr[BU256_STRSZ];
 	bu256_hex(hexstr, &block.sha256);
 
-	if (conn->nci->debugging) {
-		fprintf(conn->nci->plog, "net: %s block %s\n",
-			conn->addr_str,
-			hexstr);
-	}
+	log_debug("net: %s block %s",
+			conn->addr_str, hexstr);
 
 	if (!bp_block_valid(&block)) {
-		fprintf(conn->nci->plog, "net: %s invalid block %s\n",
-			conn->addr_str,
-			hexstr);
+		log_info("net: %s invalid block %s",
+			conn->addr_str, hexstr);
 		goto out;
 	}
 
@@ -440,7 +433,7 @@ static bool nc_conn_message(struct nc_conn *conn)
 
 	/* verify correct network */
 	if (memcmp(conn->msg.hdr.netmagic, conn->nci->chain->netmagic, 4)) {
-		fprintf(conn->nci->plog, "net: %s invalid network\n",
+		log_info("net: %s invalid network",
 			conn->addr_str);
 		return false;
 	}
@@ -451,7 +444,7 @@ static bool nc_conn_message(struct nc_conn *conn)
 
 	/* "version" must be first message */
 	if (!conn->seen_version) {
-		fprintf(conn->nci->plog, "net: %s 'version' not first\n",
+		log_info("net: %s 'version' not first",
 			conn->addr_str);
 		return false;
 	}
@@ -462,7 +455,7 @@ static bool nc_conn_message(struct nc_conn *conn)
 
 	/* "verack" must be second message */
 	if (!conn->seen_verack) {
-		fprintf(conn->nci->plog, "net: %s 'verack' not second\n",
+		log_info("net: %s 'verack' not second",
 			conn->addr_str);
 		return false;
 	}
@@ -479,10 +472,9 @@ static bool nc_conn_message(struct nc_conn *conn)
 	else if (!strncmp(command, "block", 12))
 		return nc_msg_block(conn);
 
-	if (conn->nci->debugging)
-		fprintf(conn->nci->plog, "net: %s unknown message %s\n",
-			conn->addr_str,
-			command);
+	log_debug("net: %s unknown message %s",
+		conn->addr_str,
+		command);
 
 	/* ignore unknown messages */
 	return true;
@@ -588,15 +580,14 @@ static void nc_conn_free(struct nc_conn *conn)
 
 static bool nc_conn_start(struct nc_conn *conn)
 {
-	char errpfx[64];
-
 	/* create socket */
 	conn->ipv4 = is_ipv4_mapped(conn->peer.addr.ip);
 	conn->fd = socket(conn->ipv4 ? AF_INET : AF_INET6,
 			  SOCK_STREAM, IPPROTO_TCP);
 	if (conn->fd < 0) {
-		sprintf(errpfx, "socket %s", conn->addr_str);
-		perror(errpfx);
+		log_error("net: socket %s %s",
+			conn->addr_str,
+			strerror(errno));
 		return false;
 	}
 
@@ -604,8 +595,9 @@ static bool nc_conn_start(struct nc_conn *conn)
 	int flags = fcntl(conn->fd, F_GETFL, 0);
 	if ((flags < 0) ||
 	    (fcntl(conn->fd, F_SETFL, flags | O_NONBLOCK) < 0)) {
-		sprintf(errpfx, "socket fcntl %s", conn->addr_str);
-		perror(errpfx);
+		log_error("net: socket fcntl %s %s",
+			conn->addr_str,
+			strerror(errno));
 		return false;
 	}
 
@@ -638,8 +630,9 @@ static bool nc_conn_start(struct nc_conn *conn)
 	/* initiate TCP connection */
 	if (connect(conn->fd, saddr, saddr_len) < 0) {
 		if (errno != EINPROGRESS) {
-			sprintf(errpfx, "socket connect %s", conn->addr_str);
-			perror(errpfx);
+			log_error("net: socket connect %s %s",
+				conn->addr_str,
+				strerror(errno));
 			return false;
 		}
 	}
@@ -672,7 +665,7 @@ static bool nc_conn_got_header(struct nc_conn *conn)
 static bool nc_conn_got_msg(struct nc_conn *conn)
 {
 	if (!message_valid(&conn->msg)) {
-		fprintf(conn->nci->plog, "llnet: %s invalid message\n",
+		log_info("llnet: %s invalid message",
 			conn->addr_str);
 		return false;
 	}
@@ -697,13 +690,12 @@ static void nc_conn_read_evt(int fd, short events, void *priv)
 
 	ssize_t rrc = read(fd, conn->msg_p, conn->expected);
 	if (rrc <= 0) {
-		if (rrc < 0)
-			fprintf(conn->nci->plog, "llnet: %s read: %s\n",
+		if (rrc < 0) {
+			log_info("llnet: %s read: %s",
 				conn->addr_str,
 				strerror(errno));
-		else
-			fprintf(conn->nci->plog, "llnet: %s read EOF\n", conn->addr_str);
-
+		} else
+			log_info("llnet: %s read EOF", conn->addr_str);
 		goto err_out;
 	}
 
@@ -821,7 +813,7 @@ static void nc_conn_evt_connected(int fd, short events, void *priv)
 	struct nc_conn *conn = priv;
 
 	if ((events & EV_WRITE) == 0) {
-		fprintf(conn->nci->plog, "net: %s connection timeout\n", conn->addr_str);
+		log_info("net: %s connection timeout", conn->addr_str);
 		goto err_out;
 	}
 
@@ -831,13 +823,12 @@ static void nc_conn_evt_connected(int fd, short events, void *priv)
 	/* check success of connect(2) */
 	if ((getsockopt(conn->fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0) ||
 	    (err != 0)) {
-		fprintf(conn->nci->plog, "net: connect %s failed: %s\n",
+		log_info("net: connect %s failed: %s",
 			conn->addr_str, strerror(err));
 		goto err_out;
 	}
 
-	if (conn->nci->debugging)
-		fprintf(conn->nci->plog, "net: connected to %s\n", conn->addr_str);
+	log_debug("net: connected to %s", conn->addr_str);
 
 	conn->connected = true;
 
@@ -851,7 +842,7 @@ static void nc_conn_evt_connected(int fd, short events, void *priv)
 	cstr_free(msg_data, true);
 
 	if (!rc) {
-		fprintf(conn->nci->plog, "net: %s !conn_send\n", conn->addr_str);
+		log_info("net: %s !conn_send", conn->addr_str);
 		goto err_out;
 	}
 
@@ -861,7 +852,7 @@ static void nc_conn_evt_connected(int fd, short events, void *priv)
 	conn->reading_hdr = true;
 
 	if (!nc_conn_read_enable(conn)) {
-		fprintf(conn->nci->plog, "net: %s read not enabled\n", conn->addr_str);
+		log_info("net: %s read not enabled", conn->addr_str);
 		goto err_out;
 	}
 
@@ -897,16 +888,14 @@ void nc_conns_gc(struct net_child_info *nci, bool free_all)
 
 	clist_free(dead);
 
-	if (nci->debugging)
-		fprintf(nci->plog, "net: gc'd %u connections\n", n_gc);
+	log_debug("net: gc'd %u connections", n_gc);
 }
 
 static void nc_conns_open(struct net_child_info *nci)
 {
-	if (nci->debugging)
-		fprintf(nci->plog, "net: open connections (have %zu, want %zu more)\n",
-			nci->conns->len,
-			NC_MAX_CONN - nci->conns->len);
+	log_debug("net: open connections (have %zu, want %zu more)",
+		nci->conns->len,
+		NC_MAX_CONN - nci->conns->len);
 
 	while ((bp_hashtab_size(nci->peers->map_addr) > 0) &&
 	       (nci->conns->len < NC_MAX_CONN)) {
@@ -921,27 +910,26 @@ static void nc_conns_open(struct net_child_info *nci)
 		peer_free(peer);
 		free(peer);
 
-		if (conn->nci->debugging)
-			fprintf(conn->nci->plog, "net: connecting to %s\n",
-				conn->addr_str);
+		log_debug("net: connecting to %s",
+			conn->addr_str);
 
 		/* are we already connected to this IP? */
 		if (nc_conn_ip_active(nci, conn->peer.addr.ip)) {
-			fprintf(conn->nci->plog, "net: already connected to %s\n",
+			log_info("net: already connected to %s",
 				conn->addr_str);
 			goto err_loop;
 		}
 
 		/* are we already connected to this network group? */
 		if (nc_conn_group_active(nci, &conn->peer)) {
-			fprintf(conn->nci->plog, "net: already grouped to %s\n",
+			log_info("net: already grouped to %s",
 				conn->addr_str);
 			goto err_loop;
 		}
 
 		/* initiate non-blocking connect(2) */
 		if (!nc_conn_start(conn)) {
-			fprintf(conn->nci->plog, "net: failed to start connection to %s\n",
+			log_info("net: failed to start connection to %s",
 				conn->addr_str);
 			goto err_loop;
 		}
@@ -950,14 +938,14 @@ static void nc_conns_open(struct net_child_info *nci)
 		conn->ev = event_new(nci->eb, conn->fd, EV_WRITE,
 				     nc_conn_evt_connected, conn);
 		if (!conn->ev) {
-			fprintf(conn->nci->plog, "net: event_new failed on %s\n",
+			log_info("net: event_new failed on %s",
 				conn->addr_str);
 			goto err_loop;
 		}
 
 		struct timeval timeout = { conn->nci->net_conn_timeout, };
 		if (event_add(conn->ev, &timeout) != 0) {
-			fprintf(conn->nci->plog, "net: event_add failed on %s\n",
+			log_info("net: event_add failed on %s",
 				conn->addr_str);
 			goto err_loop;
 		}
@@ -1082,10 +1070,10 @@ static void neteng_child_kill(pid_t child)
 }
 
 static bool neteng_cmd_exec(pid_t child, int read_fd, int write_fd,
-			    enum netcmds nc, bool debugging)
+			    enum netcmds nc)
 {
 	sendcmd(write_fd, nc);
-	enum netcmds ncr = readcmd(read_fd, debugging ? 1000 : 60);
+	enum netcmds ncr = readcmd(read_fd, log_state->debug ? 1000 : 60);
 	if (ncr != NC_OK)
 		return false;
 
@@ -1120,15 +1108,13 @@ bool neteng_start(struct net_engine *neteng)
 	neteng->par_read = neteng->rx_pipefd[0];
 	neteng->par_write = neteng->tx_pipefd[1];
 
-	if (neteng->debugging)
-		fprintf(neteng->plog, "net: parent exec NC_START\n");
+	log_debug("net: parent exec NC_START");
 
 	if (!neteng_cmd_exec(neteng->child, neteng->par_read,
-			     neteng->par_write, NC_START, neteng->debugging))
+			     neteng->par_write, NC_START))
 		goto err_out_child;
 
-	if (neteng->debugging)
-		fprintf(neteng->plog, "net: parent after NC_START\n");
+	log_debug("net: parent after NC_START");
 
 	neteng->running = true;
 	return true;
@@ -1153,11 +1139,10 @@ void neteng_stop(struct net_engine *neteng)
 	if (!neteng->running)
 		return;
 
-	if (neteng->debugging)
-		fprintf(neteng->plog, "net: stopping engine\n");
+	log_debug("net: stopping engine");
 
 	if (!neteng_cmd_exec(neteng->child, neteng->par_read,
-			neteng->par_write, NC_STOP, neteng->debugging))
+			neteng->par_write, NC_STOP))
 		kill(neteng->child, SIGTERM);
 
 	sleep(1);
@@ -1183,22 +1168,20 @@ void neteng_free(struct net_engine *neteng)
 	free(neteng);
 }
 
-struct net_engine *neteng_new_start(void (*network_child)(int read_fd, int write_fd), bool debugging, FILE *plog)
+struct net_engine *neteng_new_start(void (*network_child)(int read_fd, int write_fd))
 {
 	struct net_engine *neteng;
 
 	neteng = neteng_new();
 	if (!neteng) {
-		fprintf(plog, "net: neteng new fail\n");
+		log_info("net: neteng new fail");
 		exit(1);
 	}
 
 	neteng->network_child_process = network_child;
-    neteng->debugging = debugging;
-    neteng->plog = plog;
 
 	if (!neteng_start(neteng)) {
-		fprintf(plog, "net: failed to start engine\n");
+		log_info("net: failed to start engine");
 		exit(1);
 	}
 

--- a/lib/net/peerman.c
+++ b/lib/net/peerman.c
@@ -16,6 +16,7 @@
 #include <ccoin/serialize.h>            // for deser_s64, deser_u32, etc
 #include <ccoin/util.h>                 // for clist_shuffle, djb2_hash, etc
 
+#include <errno.h>                      // for errno
 #include <stdio.h>                      // for NULL, fprintf, stderr, etc
 #include <stdlib.h>                     // for free, calloc, malloc, atoi, etc
 #include <unistd.h>                     // for close, write, unlink, etc
@@ -167,7 +168,9 @@ struct peer_manager *peerman_read(void *peers_file)
 
 	int fd = file_seq_open(filename);
 	if (fd < 0) {
-		perror(filename);
+		log_error("peerman: %s: %s",
+			filename,
+			strerror(errno));
 		goto err_out;
 	}
 
@@ -291,8 +294,9 @@ bool peerman_write(struct peer_manager *peers, void *peer_file, const struct cha
 	fd = -1;
 
 	if (rename(tmpfn, filename)) {
-		strcat(tmpfn, " rename");
-		perror(tmpfn);
+		log_error("peerman: %s rename: %s",
+			tmpfn,
+			strerror(errno));
 		goto err_out;
 	}
 

--- a/lib/net/peerman.c
+++ b/lib/net/peerman.c
@@ -10,6 +10,7 @@
 #include <ccoin/hashtab.h>              // for bp_hashtab_del, etc
 #include <ccoin/message.h>              // for p2p_message, etc
 #include <ccoin/mbr.h>                  // for fread_message
+#include <ccoin/log.h>                  // for log_debug, log_error
 #include <ccoin/net/dns.h>              // for bu_dns_lookup, etc
 #include <ccoin/net/netbase.h>          // for bn_group
 #include <ccoin/serialize.h>            // for deser_s64, deser_u32, etc
@@ -18,8 +19,6 @@
 #include <stdio.h>                      // for NULL, fprintf, stderr, etc
 #include <stdlib.h>                     // for free, calloc, malloc, atoi, etc
 #include <unistd.h>                     // for close, write, unlink, etc
-
-static bool debugging = false;
 
 static unsigned long addr_hash(const void *key)
 {
@@ -94,11 +93,6 @@ static void peer_ent_free(void *data)
 
 	peer_free(peer);
 	free(peer);
-}
-
-void peerman_debug(bool _debugging)
-{
-        debugging = _debugging;
 }
 
 void peerman_free(struct peer_manager *peers)
@@ -182,13 +176,13 @@ struct peer_manager *peerman_read(void *peers_file)
 
 	while (fread_message(fd, &msg, &read_ok)) {
 		if (!peerman_read_rec(peers, &msg)) {
-			fprintf(stderr, "peerman: read record failed\n");
+			log_error("peerman: read record failed");
 			goto err_out;
 		}
 	}
 
 	if (!read_ok) {
-		fprintf(stderr, "peerman: read I/O failed\n");
+		log_error("peerman: read I/O failed");
 		goto err_out;
 	}
 
@@ -215,9 +209,8 @@ struct peer_manager *peerman_seed(bool use_dns)
 	if (use_dns)
 		seedlist = bu_dns_seed_addrs();
 
-	if (debugging)
-		fprintf(stderr, "peerman: DNS returned %zu addresses\n",
-			clist_length(seedlist));
+	log_debug("peerman: DNS returned %zu addresses",
+		clist_length(seedlist));
 
 	clist_shuffle(seedlist);
 
@@ -247,9 +240,8 @@ static bool ser_peerman(struct peer_manager *peers, int fd,  const struct chain_
 	if (wrc != rec_len)
 		return false;
 
-	if (debugging)
-		fprintf(stderr, "peerman: %zu peers to write\n",
-			clist_length(peers->addrlist));
+	log_debug("peerman: %zu peers to write",
+		clist_length(peers->addrlist));
 
 	/* write peer list */
 	clist *tmp = peers->addrlist;
@@ -397,9 +389,8 @@ void peerman_addstr(struct peer_manager *peers,
 
 	clist *tmp, *seedlist = bu_dns_lookup(NULL, hoststr, port);
 
-	if (debugging)
-		fprintf(stderr, "peerman: DNS lookup '%s' returned %zu addresses\n",
-			addr_str, clist_length(seedlist));
+	log_debug("peerman: DNS lookup '%s' returned %zu addresses\n",
+		addr_str, clist_length(seedlist));
 
 	/* import seed data into peerman */
 	tmp = seedlist;

--- a/src/brd.c
+++ b/src/brd.c
@@ -33,6 +33,7 @@
 #include <stdio.h>                      // for fprintf, NULL, fclose, etc
 #include <stdlib.h>                     // for exit, free, calloc
 #include <string.h>                     // for strerror, strcmp, strlen, etc
+#include <sys/uio.h>                    // for iovec, writev
 #include <unistd.h>                     // for lseek64, access, lseek, etc
 
 #ifdef __APPLE__

--- a/src/brd.h
+++ b/src/brd.h
@@ -8,7 +8,6 @@
 #include <ccoin/buint.h>                // for bu256_t
 #include <ccoin/hashtab.h>              // for bp_hashtab_get
 
-#include <stdbool.h>                    // for bool
 #include <stdint.h>                     // for uint64_t
 
 /* main.c */
@@ -16,7 +15,6 @@ extern struct bp_hashtab *settings;
 extern const struct chain_info *chain;
 extern bu256_t chain_genesis;
 extern uint64_t instance_nonce;
-extern bool debugging;
 
 static inline char *setting(const char *key)
 {

--- a/src/picocoin.h
+++ b/src/picocoin.h
@@ -9,7 +9,6 @@
 #include <ccoin/cstr.h>                 // for cstring
 #include <ccoin/hashtab.h>              // for bp_hashtab_get
 
-#include <stdbool.h>                    // for bool
 #include <stddef.h>                     // for size_t
 #include <stdint.h>                     // for uint64_t
 
@@ -21,7 +20,6 @@ extern struct bp_hashtab *settings;
 extern const struct chain_info *chain;
 extern bu256_t chain_genesis;
 extern uint64_t instance_nonce;
-extern bool debugging;
 extern struct wallet *cur_wallet;
 
 /* aes.c */


### PR DESCRIPTION
Hi,

When modularizing the net code a negative side effect was that for logging and debugging to still work as before the `bool debugging` and `FILE *plog``variables had to passed through a few net functions and structures,
```
struct net_child_info {
.
.
	bool			debugging;
	FILE			*plog;
.
.
};

struct net_engine {
.
.
	bool	debugging;
	FILE	*plog;
.
.
};

struct net_engine *neteng_new_start(void (*network_child)(int read_fd, int write_fd), bool debugging, FILE *plog);
```

This pull request creates a simple log framework so the  `bool debugging` and `FILE *plog` variables don't need to be passed from function to function. It also adds a timestamp to brd log files,