### PR TITLE
Travis OSX builds Fixes #91

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew upgrade; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
   # - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,14 @@ sudo: false
 env:
   global:
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - BUILD=check
     - ENABLE_COVERAGE=no
     - ENABLE_VALGRIND=no
     - secure: "rHwlRDO/xvFHScz9rCCUYVnf6okYLuSH9HMqvZPVwI/CFb9FlUnTYfXBnI0eEK/9PVrl2Q8CLxJpdUn0P7zSwcLlI1PaLWpx0W5meM4JDtYRaI4wbwNjOg2ziM20LgzEWeFSk+XvJQMuOEuW6z7T0NZl9se2MTfBfgQZs9cCH8WmMvjN2hFNXGfoROLbHtEGPo7pc0ob7WkAxQ3aJ1fm7ehCU1V7SxxrLFVWY37xrwRMeUBPLcV/F5owtZrOZFAB6burrrUy1kZhZEcrJRMrA8oFESK4cOdnpZEY5B3db3XBW1MtgFJXh+b6TbwkRIjYDgjt6OkGqAsgguaB3NJ1UENxT/S86Q6tvWRuh7E1d56IcGrb+BLF9S8KiYgr/iPfC8hmbGdV0PbLkSXL5/+03wMTmww4MwaDKq8TkMXRvuc8cdm73jxqoQhqhDxYbOr8z1zAFeCasPukE7unb7McuF85kdX1VAEcq7K70mz292BKGOVHi55KGpGf+QlXpecsjRIV7XkArK9NI1VyZDfJpsRjzBmz5K9wp08gT/bbKYuEeaQlkOk3b4qlSYGLA3HnYD0UweSYuEvux0flQoS6QAiYmTWRe5qmEVzo22L5h9x3f2+Fv93d7hwu1UAwLe5zs83YLURdzu6OQwAnk8imzya4hk3+nqU05PVFN9b65Fk="
-    - MAKEJOBS=-j3
 
   matrix:
-    - BUILD=distcheck MAKEJOBS=-j3
-    - ENABLE_COVERAGE=yes
-    - ENABLE_VALGRIND=yes
+    - MAKETARGET=distcheck MAKEJOBS=-j3
+    - MAKETARGET=check MAKEJOBS=-j1 ENABLE_COVERAGE=yes
+    - MAKETARGET=check MAKEJOBS=-j1 ENABLE_VALGRIND=yes
 
 cache:
   apt: true
@@ -50,7 +48,6 @@ addons:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-  # - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install jansson; fi
@@ -67,11 +64,12 @@ before_script:
 
 script:
   - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
-  - PICOCOIN_CONFIG_ALL="--prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-  - ./configure --cache-file=config.cache --enable-coverage=$ENABLE_COVERAGE --enable-valgrind=$ENABLE_VALGRIND $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
-  - make -s $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL ; false )
+  - PICOCOIN_CONFIG="--enable-coverage=$ENABLE_COVERAGE --enable-valgrind=$ENABLE_VALGRIND"
+  - PICOCOIN_CONFIG_ALL="--prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib --cache-file=config.cache  "
+  - ./configure $PICOCOIN_CONFIG_ALL $PICOCOIN_CONFIG || ( cat config.log && false)
+  - make -s $MAKEJOBS || ( echo "Build failure. Verbose build follows." && make V=1 ; false )
   - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
-  - make $MAKEJOBS $BUILD
+  - make $MAKEJOBS $MAKETARGET
 
 after_success:
   - if [ "$ENABLE_COVERAGE" = "yes" ]; then lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode8
+
 sudo: false
 
 env:

--- a/include/ccoin/crypto/aes_util.h
+++ b/include/ccoin/crypto/aes_util.h
@@ -9,10 +9,18 @@
 
 #include <stdbool.h>                    // for bool
 #include <stddef.h>                     // for size_t
+#include <string.h>                     // for memcpy, memset
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define AES256_BLOCK_LENGTH             16
+#define AES256_KEY_LENGTH               32
+
+#define MEMSET_BZERO(p,l)     memset((p), 0, (l))
+#define MEMCPY_BCOPY(d,s,l)   memcpy((d), (s), (l))
 
 extern cstring *read_aes_file(const char *filename, void *key, size_t key_len,
 			      size_t max_file_len);


### PR DESCRIPTION
Hi,

Recently Travis CI have been making lots of changes around the default versions of XCode used. This has wreaked havoc on picocoin builds.

The commits in this pull reques tmake several changes so that now all builds succeed on Travis.

Most of the changes are in the `.travis.yml` file but there are some code changes in `aes_util.c`. The change here was because of some stack issue when optimization `-O2` was used. I am not sure why the problem occurred or why the implemented fix works, but it does:

```c
bool write_aes_file(const char *filename_, void *key_data, size_t key_data_len,
		    const void *plaintext, size_t pt_len)
{
    char *filename = malloc(strlen(filename_) + 1);
    .
    .
    .
    strcpy(filename, filename_);
    .
    .
    .
}
```