### PR TITLE
Fix failing CSV tests

### DIFF
--- a/lib/script_eval.c
+++ b/lib/script_eval.c
@@ -728,7 +728,7 @@ static bool bp_script_eval(parr *stack, const cstring *script,
 			if (mpz_sgn(bn) < 0)
 				goto out;
 
-			uint64_t nSequence = mpz_get_ui(bn);
+			uint32_t nSequence = mpz_get_ui(bn);
 
 			// To provide for future soft-fork extensibility, if the
 			// operand has the disabled lock-time flag set,

--- a/test/script.c
+++ b/test/script.c
@@ -11,14 +11,65 @@
 #include <ccoin/core.h>
 #include "libtest.h"
 
+struct bp_tx BuildCreditingTransaction(struct cstring *scriptPubKey)
+{
+    struct bp_tx txCredit;
+    bp_tx_init(&txCredit);
+    txCredit.nVersion = 1;
+    txCredit.nLockTime = 0;
+    txCredit.vin = parr_new(0, bp_txin_freep);
+    txCredit.vout = parr_new(0, bp_txout_freep);
+
+    struct bp_txin *txinCredit = calloc(1, sizeof(struct bp_txin));
+    bp_txin_init(txinCredit);
+    bp_outpt_null(&txinCredit->prevout);
+    txinCredit->scriptSig = cstr_new(NULL);
+    txinCredit->nSequence = SEQUENCE_FINAL;
+    parr_add(txCredit.vin, txinCredit);
+
+    struct bp_txout *txoutCredit = calloc(1, sizeof(struct bp_txout));
+    bp_txout_init(txoutCredit);
+    txoutCredit->scriptPubKey = cstr_new_buf(scriptPubKey->str, scriptPubKey->len);
+    txoutCredit->nValue = (uint64_t) 0;
+    parr_add(txCredit.vout, txoutCredit);
+    bp_tx_calc_sha256(&txCredit);
+
+    return txCredit;
+}
+
+struct bp_tx BuildSpendingTransaction(struct cstring *scriptSig, struct bp_tx txCredit)
+{
+    struct bp_tx txSpend;
+    bp_tx_init(&txSpend);
+    txSpend.nVersion = 1;
+    txSpend.nLockTime = 0;
+    txSpend.vin = parr_new(0, bp_txin_freep);
+    txSpend.vout = parr_new(0, bp_txout_freep);
+
+    struct bp_txin *txinSpend = calloc(1, sizeof(struct bp_txin));
+    bp_txin_init(txinSpend);
+    bu256_copy(&txinSpend->prevout.hash, &txCredit.sha256);
+    txinSpend->prevout.n = 0;
+    txinSpend->scriptSig = cstr_new_buf(scriptSig->str, scriptSig->len);
+    txinSpend->nSequence = SEQUENCE_FINAL;
+    parr_add(txSpend.vin, txinSpend);
+
+    struct bp_txout *txoutSpend = calloc(1, sizeof(struct bp_txout));
+    bp_txout_init(txoutSpend);
+    txoutSpend->scriptPubKey = cstr_new(NULL); //
+    txoutSpend->nValue =(uint64_t) 0;
+    parr_add(txSpend.vout, txoutSpend);
+
+    bp_tx_free(&txCredit);
+    return txSpend;
+}
+
 static void test_script(bool is_valid,cstring *scriptSig, cstring *scriptPubKey,
 			unsigned int idx, const char *scriptSigEnc,
 			const char *scriptPubKeyEnc,
 			const unsigned int test_flags)
 {
-	struct bp_tx tx;
-
-	bp_tx_init(&tx);
+	struct bp_tx tx = BuildSpendingTransaction(scriptSig, BuildCreditingTransaction(scriptPubKey));
 
 	bool rc;
 	rc = bp_script_verify(scriptSig, scriptPubKey, &tx, 0,

--- a/test/script_tests.json
+++ b/test/script_tests.json
@@ -1430,6 +1430,8 @@
 ["", "CHECKSEQUENCEVERIFY", "", "INVALID_STACK_OPERATION", "CSV automatically fails on a empty stack"],
 ["-1", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "NEGATIVE_LOCKTIME", "CSV automatically fails if stack top is negative"],
 ["0x0100", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY,MINIMALDATA", "UNKNOWN_ERROR", "CSV fails if stack top is not minimally encoded"],
-
+["0", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME", "CSV fails if stack top bit 1 << 31 is set and the tx version < 2"],
+["4294967296", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME",
+  "CSV fails if stack top bit 1 << 31 is not set, and tx version < 2"],
 ["The End"]
 ]


### PR DESCRIPTION
Hi,

This PR fixes some of the script tests issues highlighted in #83 

The following two CSV tests now pass:
```json
["0", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME", "CSV fails if stack top bit 1 << 31 is set and the tx version < 2"],
["4294967296", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME",
  "CSV fails if stack top bit 1 << 31 is not set, and tx version < 2"],
```
